### PR TITLE
[FEAT] 이메일 인증 코드 발송 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,14 +28,25 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
 	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
-	annotationProcessor 'org.projectlombok:lombok'
-
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	testRuntimeOnly 'com.h2database:h2'
+
+	testImplementation platform('org.testcontainers:testcontainers-bom:1.19.8')
+
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.awaitility:awaitility'
+
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/terning/farewell_server/auth/api/AuthController.java
+++ b/src/main/java/com/terning/farewell_server/auth/api/AuthController.java
@@ -1,0 +1,25 @@
+package com.terning.farewell_server.auth.api;
+
+import com.terning.farewell_server.auth.dto.EmailRequest;
+import com.terning.farewell_server.auth.application.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/send-verification-code")
+    public ResponseEntity<String> sendVerificationCode(@Valid @RequestBody EmailRequest request) {
+        authService.sendVerificationCode(request.email());
+        return ResponseEntity.ok("인증 코드가 성공적으로 발송되었습니다.");
+    }
+}

--- a/src/main/java/com/terning/farewell_server/auth/application/AuthService.java
+++ b/src/main/java/com/terning/farewell_server/auth/application/AuthService.java
@@ -1,0 +1,19 @@
+package com.terning.farewell_server.auth.application;
+
+import com.terning.farewell_server.mail.application.EmailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final EmailService emailService;
+    private final VerificationCodeManager verificationCodeManager;
+
+    public void sendVerificationCode(String email) {
+        String code = verificationCodeManager.issueCode(email);
+
+        emailService.sendVerificationCode(email, code);
+    }
+}

--- a/src/main/java/com/terning/farewell_server/auth/application/VerificationCodeManager.java
+++ b/src/main/java/com/terning/farewell_server/auth/application/VerificationCodeManager.java
@@ -1,0 +1,37 @@
+package com.terning.farewell_server.auth.application;
+
+import com.terning.farewell_server.global.common.RedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Random;
+
+@Component
+@RequiredArgsConstructor
+public class VerificationCodeManager {
+
+    private final RedisService redisService;
+
+    private static final String VERIFICATION_CODE_PREFIX = "verification:";
+    private static final Duration VERIFICATION_CODE_TTL = Duration.ofMinutes(5);
+
+    public String issueCode(String email) {
+        String code = createVerificationCode();
+        String redisKey = VERIFICATION_CODE_PREFIX + email;
+        redisService.setDataWithExpiration(redisKey, code, VERIFICATION_CODE_TTL);
+        return code;
+    }
+
+    private String createVerificationCode() {
+        Random random = new Random();
+        int code = 100000 + random.nextInt(900000);
+        return String.valueOf(code);
+    }
+
+    public boolean verifyCode(String email, String codeToVerify) {
+        String redisKey = VERIFICATION_CODE_PREFIX + email;
+        String storedCode = redisService.getData(redisKey);
+        return codeToVerify.equals(storedCode);
+    }
+}

--- a/src/main/java/com/terning/farewell_server/auth/application/VerificationCodeManager.java
+++ b/src/main/java/com/terning/farewell_server/auth/application/VerificationCodeManager.java
@@ -4,8 +4,8 @@ import com.terning.farewell_server.global.common.RedisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.security.SecureRandom;
 import java.time.Duration;
-import java.util.Random;
 
 @Component
 @RequiredArgsConstructor
@@ -24,8 +24,8 @@ public class VerificationCodeManager {
     }
 
     private String createVerificationCode() {
-        Random random = new Random();
-        int code = 100000 + random.nextInt(900000);
+        SecureRandom secureRandom = new SecureRandom();
+        int code = 100000 + secureRandom.nextInt(900000);
         return String.valueOf(code);
     }
 

--- a/src/main/java/com/terning/farewell_server/auth/dto/EmailRequest.java
+++ b/src/main/java/com/terning/farewell_server/auth/dto/EmailRequest.java
@@ -1,0 +1,10 @@
+package com.terning.farewell_server.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailRequest(
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "유효하지 않은 이메일 형식입니다.")
+        String email
+) {}

--- a/src/main/java/com/terning/farewell_server/global/common/RedisService.java
+++ b/src/main/java/com/terning/farewell_server/global/common/RedisService.java
@@ -1,0 +1,26 @@
+package com.terning.farewell_server.global.common;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void setDataWithExpiration(String key, String value, Duration duration) {
+        redisTemplate.opsForValue().set(key, value, duration);
+    }
+
+    public String getData(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void deleteData(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/terning/farewell_server/mail/application/EmailService.java
+++ b/src/main/java/com/terning/farewell_server/mail/application/EmailService.java
@@ -1,0 +1,47 @@
+package com.terning.farewell_server.mail.application;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender javaMailSender;
+    private final SpringTemplateEngine templateEngine;
+
+    private static final String VERIFICATION_EMAIL_SUBJECT = "[터닝] 마지막 선물 신청을 위한 인증 코드입니다.";
+
+    public void sendVerificationCode(String toEmail, String code) {
+        Context context = new Context();
+        context.setVariable("code", code);
+
+        String htmlContent = templateEngine.process("verificationCode", context);
+
+        sendEmail(toEmail, VERIFICATION_EMAIL_SUBJECT, htmlContent);
+    }
+
+    private void sendEmail(String toEmail, String subject, String htmlBody) {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        try {
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+            mimeMessageHelper.setTo(toEmail);
+            mimeMessageHelper.setSubject(subject);
+            mimeMessageHelper.setText(htmlBody, true);
+
+            javaMailSender.send(mimeMessage);
+            log.info("이메일 발송 성공! 수신자: {}, 제목: {}", toEmail, subject);
+        } catch (MessagingException e) {
+            log.error("이메일 발송 실패. 수신자: {}", toEmail, e);
+            throw new RuntimeException("이메일 발송에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/terning/farewell_server/mail/application/EmailService.java
+++ b/src/main/java/com/terning/farewell_server/mail/application/EmailService.java
@@ -41,7 +41,7 @@ public class EmailService {
             log.info("이메일 발송 성공! 수신자: {}, 제목: {}", toEmail, subject);
         } catch (MessagingException e) {
             log.error("이메일 발송 실패. 수신자: {}", toEmail, e);
-            throw new RuntimeException("이메일 발송에 실패했습니다.");
+            throw new RuntimeException("이메일 발송에 실패했습니다.", e);
         }
     }
 }

--- a/src/test/java/com/terning/farewell_server/auth/api/AuthControllerTest.java
+++ b/src/test/java/com/terning/farewell_server/auth/api/AuthControllerTest.java
@@ -1,0 +1,94 @@
+package com.terning.farewell_server.auth.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.terning.farewell_server.auth.application.AuthService;
+import com.terning.farewell_server.auth.dto.EmailRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AuthService authService;
+
+    @Test
+    @DisplayName("유효한 이메일로 인증 코드 발송을 요청하면 성공(200 OK)한다.")
+    void sendVerificationCode_Success() throws Exception {
+        // given
+        EmailRequest request = new EmailRequest("test@example.com");
+        String requestBody = objectMapper.writeValueAsString(request);
+
+        doNothing().when(authService).sendVerificationCode("test@example.com");
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/auth/send-verification-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(content().string("인증 코드가 성공적으로 발송되었습니다."));
+
+        verify(authService).sendVerificationCode("test@example.com");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 이메일 형식으로 요청하면 실패(400 Bad Request)한다.")
+    void sendVerificationCode_Fail_InvalidEmail() throws Exception {
+        // given
+        EmailRequest request = new EmailRequest("invalid-email");
+        String requestBody = objectMapper.writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/auth/send-verification-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("이메일을 비워서 요청하면 실패(400 Bad Request)한다.")
+    void sendVerificationCode_Fail_BlankEmail() throws Exception {
+        // given
+        EmailRequest request = new EmailRequest("");
+        String requestBody = objectMapper.writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/auth/send-verification-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/terning/farewell_server/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/terning/farewell_server/auth/application/AuthServiceTest.java
@@ -1,0 +1,52 @@
+package com.terning.farewell_server.auth.application;
+
+import com.terning.farewell_server.mail.application.EmailService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private VerificationCodeManager verificationCodeManager;
+
+    @Mock
+    private EmailService emailService;
+
+    @InjectMocks
+    private AuthService authService;
+
+    private static final String EMAIL = "test@example.com";
+    private static final String MOCK_CODE = "123456";
+
+    @Test
+    @DisplayName("인증 코드 발송 요청 시, 매니저와 이메일 서비스가 올바른 순서로 호출되어야 한다.")
+    void sendVerificationCode_should_call_dependencies_in_correct_order() {
+        // given
+        when(verificationCodeManager.issueCode(EMAIL)).thenReturn(MOCK_CODE);
+
+        doNothing().when(emailService).sendVerificationCode(EMAIL, MOCK_CODE);
+
+        // when
+        authService.sendVerificationCode(EMAIL);
+
+        // then
+        verify(verificationCodeManager, times(1)).issueCode(EMAIL);
+        verify(emailService, times(1)).sendVerificationCode(EMAIL, MOCK_CODE);
+
+        InOrder inOrder = inOrder(verificationCodeManager, emailService);
+        inOrder.verify(verificationCodeManager).issueCode(EMAIL);
+        inOrder.verify(emailService).sendVerificationCode(EMAIL, MOCK_CODE);
+    }
+}

--- a/src/test/java/com/terning/farewell_server/auth/application/VerificationCodeManagerTest.java
+++ b/src/test/java/com/terning/farewell_server/auth/application/VerificationCodeManagerTest.java
@@ -1,0 +1,91 @@
+package com.terning.farewell_server.auth.application;
+
+import com.terning.farewell_server.global.common.RedisService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class VerificationCodeManagerTest {
+
+    @Mock
+    private RedisService redisService;
+
+    @InjectMocks
+    private VerificationCodeManager verificationCodeManager;
+
+    private static final String EMAIL = "test@example.com";
+    private static final String VERIFICATION_CODE_PREFIX = "verification:";
+    private static final Duration VERIFICATION_CODE_TTL = Duration.ofMinutes(5);
+
+    @Test
+    @DisplayName("인증 코드 발급 시 Redis에 올바른 값으로 저장되어야 한다")
+    void issueCode_should_save_code_to_redis() {
+        // given
+
+        // when
+        String code = verificationCodeManager.issueCode(EMAIL);
+
+        // then
+        assertThat(code).hasSize(6);
+        assertThat(code).matches("\\d{6}");
+
+        verify(redisService, times(1)).setDataWithExpiration(
+                VERIFICATION_CODE_PREFIX + EMAIL,
+                code,
+                VERIFICATION_CODE_TTL
+        );
+    }
+
+    @Test
+    @DisplayName("유효한 코드로 검증 요청 시 true를 반환해야 한다")
+    void verifyCode_with_valid_code_should_return_true() {
+        // given
+        String validCode = "123456";
+        when(redisService.getData(VERIFICATION_CODE_PREFIX + EMAIL)).thenReturn(validCode);
+
+        // when
+        boolean isValid = verificationCodeManager.verifyCode(EMAIL, validCode);
+
+        // then
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 코드로 검증 요청 시 false를 반환해야 한다")
+    void verifyCode_with_invalid_code_should_return_false() {
+        // given
+        String storedCode = "123456";
+        String invalidCode = "654321";
+        when(redisService.getData(VERIFICATION_CODE_PREFIX + EMAIL)).thenReturn(storedCode);
+
+        // when
+        boolean isValid = verificationCodeManager.verifyCode(EMAIL, invalidCode);
+
+        // then
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    @DisplayName("Redis에 코드가 없는 경우 false를 반환해야 한다")
+    void verifyCode_with_no_code_in_redis_should_return_false() {
+        // given
+        when(redisService.getData(VERIFICATION_CODE_PREFIX + EMAIL)).thenReturn(null);
+        String codeToVerify = "123456";
+
+        // when
+        boolean isValid = verificationCodeManager.verifyCode(EMAIL, codeToVerify);
+
+        // then
+        assertThat(isValid).isFalse();
+    }
+}

--- a/src/test/java/com/terning/farewell_server/global/common/RedisServiceIntegrationTest.java
+++ b/src/test/java/com/terning/farewell_server/global/common/RedisServiceIntegrationTest.java
@@ -1,0 +1,101 @@
+package com.terning.farewell_server.global.common;
+
+import com.terning.farewell_server.auth.application.AuthService;
+import com.terning.farewell_server.mail.application.EmailService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
+
+@SpringBootTest
+@Testcontainers
+@ActiveProfiles("test")
+class RedisServiceIntegrationTest {
+
+    @Autowired
+    private RedisService redisService;
+
+    @Container
+    public static GenericContainer<?> redis = new GenericContainer<>("redis:7.0.12-alpine")
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void setRedisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        public AuthService authService() {
+            return mock(AuthService.class);
+        }
+
+        @Bean
+        public EmailService emailService() {
+            return mock(EmailService.class);
+        }
+    }
+
+    @Test
+    @DisplayName("데이터와 만료 시간을 설정하고, 만료 후 데이터가 삭제되는지 확인한다.")
+    void setDataWithExpiration_should_save_and_expire_data() {
+        // given
+        String key = "test:key";
+        String value = "test:value";
+        Duration ttl = Duration.ofSeconds(5);
+
+        // when
+        redisService.setDataWithExpiration(key, value, ttl);
+
+        // then
+        assertThat(redisService.getData(key)).isEqualTo(value);
+
+        await().atMost(Duration.ofSeconds(6)).untilAsserted(() -> {
+            assertThat(redisService.getData(key)).isNull();
+        });
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 키를 조회하면 null을 반환한다.")
+    void getData_should_return_null_for_non_existent_key() {
+        // given
+        String nonExistentKey = "nonExistent:key";
+
+        // when
+        String result = redisService.getData(nonExistentKey);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("데이터를 삭제하면 정상적으로 제거된다.")
+    void deleteData_should_remove_data() {
+        // given
+        String key = "delete:key";
+        String value = "delete:value";
+        redisService.setDataWithExpiration(key, value, Duration.ofMinutes(1));
+
+        // when
+        redisService.deleteData(key);
+
+        // then
+        assertThat(redisService.getData(key)).isNull();
+    }
+}

--- a/src/test/java/com/terning/farewell_server/mail/application/EmailServiceTest.java
+++ b/src/test/java/com/terning/farewell_server/mail/application/EmailServiceTest.java
@@ -1,6 +1,7 @@
 package com.terning.farewell_server.mail.application;
 
 import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,8 @@ import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -47,7 +50,7 @@ class EmailServiceTest {
     @DisplayName("유효한 이메일과 코드로 이메일 전송을 요청하면 성공해야 한다.")
     void sendVerificationCode_should_send_email_successfully() throws MessagingException {
         // given
-        MimeMessage mimeMessage = new MimeMessage((jakarta.mail.Session) null);
+        MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()));
 
         when(templateEngine.process(eq("verificationCode"), any(Context.class))).thenReturn(MOCK_HTML_CONTENT);
         when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
@@ -67,7 +70,7 @@ class EmailServiceTest {
     @DisplayName("이메일 발송 실패 시 RuntimeException을 던져야 한다.")
     void sendVerificationCode_should_throw_exception_on_failure() {
         // given
-        MimeMessage mimeMessage = new MimeMessage((jakarta.mail.Session) null);
+        MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()));
 
         when(templateEngine.process(eq("verificationCode"), any(Context.class))).thenReturn(MOCK_HTML_CONTENT);
         when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);

--- a/src/test/java/com/terning/farewell_server/mail/application/EmailServiceTest.java
+++ b/src/test/java/com/terning/farewell_server/mail/application/EmailServiceTest.java
@@ -1,0 +1,79 @@
+package com.terning.farewell_server.mail.application;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTest {
+
+    @Mock
+    private JavaMailSender javaMailSender;
+
+    @Mock
+    private SpringTemplateEngine templateEngine;
+
+    @InjectMocks
+    private EmailService emailService;
+
+    @Captor
+    private ArgumentCaptor<MimeMessage> mimeMessageCaptor;
+
+    private static final String TO_EMAIL = "test@example.com";
+    private static final String CODE = "123456";
+    private static final String MOCK_HTML_CONTENT = "<html>...</html>";
+    private static final String VERIFICATION_EMAIL_SUBJECT = "[터닝] 마지막 선물 신청을 위한 인증 코드입니다.";
+
+    @Test
+    @DisplayName("유효한 이메일과 코드로 이메일 전송을 요청하면 성공해야 한다.")
+    void sendVerificationCode_should_send_email_successfully() throws MessagingException {
+        // given
+        MimeMessage mimeMessage = new MimeMessage((jakarta.mail.Session) null);
+
+        when(templateEngine.process(eq("verificationCode"), any(Context.class))).thenReturn(MOCK_HTML_CONTENT);
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        // when
+        emailService.sendVerificationCode(TO_EMAIL, CODE);
+
+        // then
+        verify(javaMailSender).send(mimeMessageCaptor.capture());
+        MimeMessage capturedMessage = mimeMessageCaptor.getValue();
+
+        assertThat(capturedMessage.getSubject()).isEqualTo(VERIFICATION_EMAIL_SUBJECT);
+        assertThat(capturedMessage.getRecipients(MimeMessage.RecipientType.TO)[0].toString()).isEqualTo(TO_EMAIL);
+    }
+
+    @Test
+    @DisplayName("이메일 발송 실패 시 RuntimeException을 던져야 한다.")
+    void sendVerificationCode_should_throw_exception_on_failure() {
+        // given
+        MimeMessage mimeMessage = new MimeMessage((jakarta.mail.Session) null);
+
+        when(templateEngine.process(eq("verificationCode"), any(Context.class))).thenReturn(MOCK_HTML_CONTENT);
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+        doThrow(new MailSendException("Failed to send email")).when(javaMailSender).send(any(MimeMessage.class));
+
+        // when & then
+        assertThrows(RuntimeException.class, () -> emailService.sendVerificationCode(TO_EMAIL, CODE));
+    }
+}


### PR DESCRIPTION
# 🚀 작업 내용

  - **이메일 인증 API 구현**: `/api/auth/send-verification-code` 엔드포인트를 통해 인증 코드 발송 기능을 구현했습니다.
  - **서비스 계층 설계**: 객체지향 원칙에 따라 `AuthService`(흐름 제어), `VerificationCodeManager`(인증 코드 관리), `RedisService`(데이터 접근)로 책임을 명확히 분리하여 설계했습니다.
  - **Thymeleaf 템플릿 적용**: 이메일 본문을 동적으로 생성하기 위해 Thymeleaf 템플릿 엔진을 도입하여 콘텐츠 관리를 용이하게 만들었습니다.
  - **DTO 설계**: `EmailRequest` DTO를 Java `record`로 구현하여 불변성을 보장하고 코드를 간결하게 작성했습니다.
  - **단위 및 통합 테스트**: 구현한 모든 기능에 대해 Mockito를 사용한 단위 테스트와 Testcontainers를 사용한 통합 테스트를 작성하여 코드 안정성을 확보했습니다.
  - **테스트 환경 구축**: `build.gradle`에 Testcontainers, H2 등 테스트에 필요한 의존성을 추가했습니다.

# 💬 리뷰 중점 사항

- **서비스 역할 분리와 응집도**: `AuthService`에 인증 코드 생성 및 검증 로직을 포함할지 고민하다가, 응집도를 높이기 위해 `VerificationCodeManager`로 분리했습니다. `AuthService`(조정), `VerificationCodeManager`(인증 관리), `RedisService`(데이터 접근) 간의 역할 분리가 명확하고 적절하게 이루어졌는지 중점적으로 확인 부탁드립니다.
- **테스트 전략**: 각 테스트의 목적(단위/통합)에 맞게 Mockito와 Testcontainers가 효과적으로 사용되었는지 리뷰 부탁드립니다.
- **ArgumentCaptor 활용**: `EmailServiceTest`에서 이메일 제목과 수신자까지 검증하기 위해 `ArgumentCaptor`를 사용했는데, 이 방식이 적절한지 의견 부탁드립니다.

## 📸 Test Screens
<img width="630" height="307" alt="스크린샷 2025-08-22 오전 9 41 30" src="https://github.com/user-attachments/assets/7125fda3-58e5-482a-af42-cbe47b19b96c" />
hot


<img width="361" height="145" alt="스크린샷 2025-08-22 오전 9 42 04" src="https://github.com/user-attachments/assets/27b97f39-9371-4072-8d45-c994ce0b3639" />

# 📋 연관 이슈

- close #16 