### PR TITLE
[FEAT] 글로벌 예외 및 성공 응답 처리 모듈 추가 및 AuthController 개선

### DIFF
--- a/src/main/java/com/terning/farewell_server/auth/api/AuthController.java
+++ b/src/main/java/com/terning/farewell_server/auth/api/AuthController.java
@@ -4,7 +4,6 @@ import com.terning.farewell_server.auth.dto.EmailRequest;
 import com.terning.farewell_server.auth.application.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,8 +17,7 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/send-verification-code")
-    public ResponseEntity<String> sendVerificationCode(@Valid @RequestBody EmailRequest request) {
+    public void sendVerificationCode(@Valid @RequestBody EmailRequest request) {
         authService.sendVerificationCode(request.email());
-        return ResponseEntity.ok("인증 코드가 성공적으로 발송되었습니다.");
     }
 }

--- a/src/main/java/com/terning/farewell_server/auth/application/VerificationCodeManager.java
+++ b/src/main/java/com/terning/farewell_server/auth/application/VerificationCodeManager.java
@@ -1,5 +1,7 @@
 package com.terning.farewell_server.auth.application;
 
+import com.terning.farewell_server.auth.exception.AuthErrorCode;
+import com.terning.farewell_server.auth.exception.AuthException;
 import com.terning.farewell_server.global.common.RedisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -29,9 +31,14 @@ public class VerificationCodeManager {
         return String.valueOf(code);
     }
 
-    public boolean verifyCode(String email, String codeToVerify) {
+    public void verifyCode(String email, String codeToVerify) {
         String redisKey = VERIFICATION_CODE_PREFIX + email;
         String storedCode = redisService.getData(redisKey);
-        return codeToVerify.equals(storedCode);
+
+        if (storedCode == null || !codeToVerify.equals(storedCode)) {
+            throw new AuthException(AuthErrorCode.INVALID_VERIFICATION_CODE);
+        }
+
+        redisService.deleteData(redisKey);
     }
 }

--- a/src/main/java/com/terning/farewell_server/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/terning/farewell_server/auth/exception/AuthErrorCode.java
@@ -1,0 +1,27 @@
+package com.terning.farewell_server.auth.exception;
+
+import com.terning.farewell_server.global.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "유효하지 않거나 만료된 인증 코드입니다.");
+
+    private static final String PREFIX = "[AUTH ERROR] ";
+
+    private final HttpStatus status;
+    private final String rawMessage;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return PREFIX + rawMessage;
+    }
+}

--- a/src/main/java/com/terning/farewell_server/auth/exception/AuthException.java
+++ b/src/main/java/com/terning/farewell_server/auth/exception/AuthException.java
@@ -1,0 +1,11 @@
+package com.terning.farewell_server.auth.exception;
+
+import com.terning.farewell_server.global.error.BaseException;
+import com.terning.farewell_server.global.error.ErrorCode;
+
+public class AuthException extends BaseException {
+
+    public AuthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/terning/farewell_server/global/GlobalResponseAdvice.java
+++ b/src/main/java/com/terning/farewell_server/global/GlobalResponseAdvice.java
@@ -1,0 +1,36 @@
+package com.terning.farewell_server.global;
+
+import com.terning.farewell_server.global.error.ErrorResponse;
+import com.terning.farewell_server.global.success.GlobalSuccessCode;
+import com.terning.farewell_server.global.success.SuccessResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice(basePackages = "com.terning.farewell_server")
+public class GlobalResponseAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        Class<?> parameterType = returnType.getParameterType();
+        return !(parameterType.equals(ErrorResponse.class) ||
+                parameterType.equals(SuccessResponse.class) ||
+                parameterType.equals(ResponseEntity.class));
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request, ServerHttpResponse response) {
+        if (body == null) {
+            return SuccessResponse.from(GlobalSuccessCode.OK);
+        }
+
+        return SuccessResponse.of(GlobalSuccessCode.OK, body);
+    }
+}

--- a/src/main/java/com/terning/farewell_server/global/error/BaseException.java
+++ b/src/main/java/com/terning/farewell_server/global/error/BaseException.java
@@ -1,0 +1,19 @@
+package com.terning.farewell_server.global.error;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BaseException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BaseException(ErrorCode errorCode, Object... args) {
+        super(errorCode.getMessage(args));
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/terning/farewell_server/global/error/ErrorCode.java
+++ b/src/main/java/com/terning/farewell_server/global/error/ErrorCode.java
@@ -1,0 +1,12 @@
+package com.terning.farewell_server.global.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getStatus();
+    String getMessage();
+
+    default String getMessage(Object... args){
+        return String.format(this.getMessage(), args);
+    }
+}

--- a/src/main/java/com/terning/farewell_server/global/error/ErrorCode.java
+++ b/src/main/java/com/terning/farewell_server/global/error/ErrorCode.java
@@ -6,7 +6,7 @@ public interface ErrorCode {
     HttpStatus getStatus();
     String getMessage();
 
-    default String getMessage(Object... args){
+    default String getMessage(Object... args) {
         return String.format(this.getMessage(), args);
     }
 }

--- a/src/main/java/com/terning/farewell_server/global/error/ErrorResponse.java
+++ b/src/main/java/com/terning/farewell_server/global/error/ErrorResponse.java
@@ -1,0 +1,4 @@
+package com.terning.farewell_server.global.error;
+
+public record ErrorResponse(int status, String message) {
+}

--- a/src/main/java/com/terning/farewell_server/global/error/GlobalErrorCode.java
+++ b/src/main/java/com/terning/farewell_server/global/error/GlobalErrorCode.java
@@ -1,0 +1,32 @@
+package com.terning.farewell_server.global.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력 값입니다."),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "리소스를 찾을 수 없습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 메소드입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
+    MISSING_HEADER(HttpStatus.BAD_REQUEST, "요청에 필요한 헤더가 존재하지 않습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근이 금지되었습니다.");
+
+    private static final String PREFIX = "[GLOBAL ERROR] ";
+
+    private final HttpStatus status;
+    private final String rawMessage;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return PREFIX + rawMessage;
+    }
+}

--- a/src/main/java/com/terning/farewell_server/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/terning/farewell_server/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,70 @@
+package com.terning.farewell_server.global.error;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BaseException.class)
+    protected ResponseEntity<ErrorResponse> handleBaseException(BaseException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.warn(">> 비즈니스 예외 발생: {}", e.getMessage(), e);
+        return createResponseEntity(errorCode, e.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        ErrorCode errorCode = GlobalErrorCode.INVALID_INPUT_VALUE;
+
+        String detailMessage = e.getBindingResult().getFieldErrors().stream()
+                .map(fieldError -> String.format("'%s' 필드: %s", fieldError.getField(), fieldError.getDefaultMessage()))
+                .collect(Collectors.joining(", "));
+
+        log.warn(">> 입력값 유효성 검사 실패: {}", detailMessage);
+        return createResponseEntity(errorCode, detailMessage);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e, HttpServletRequest request) {
+        log.warn(">> 지원하지 않는 HTTP 메소드 요청: [{}], 요청 URI: [{}]", e.getMethod(), request.getRequestURI());
+        return createResponseEntity(GlobalErrorCode.METHOD_NOT_ALLOWED);
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    protected ResponseEntity<ErrorResponse> handleMissingRequestHeaderException(MissingRequestHeaderException e) {
+        ErrorCode errorCode = GlobalErrorCode.MISSING_HEADER;
+        String message = String.format("필수 헤더('%s')가 요청에 포함되지 않았습니다.", e.getHeaderName());
+        log.warn(">> 필수 요청 헤더 누락: {}", message);
+        return createResponseEntity(errorCode, message);
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error(">> 처리되지 않은 예외 발생: {}", e.getMessage(), e);
+        return createResponseEntity(GlobalErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    private ResponseEntity<ErrorResponse> createResponseEntity(ErrorCode errorCode) {
+        return new ResponseEntity<>(
+                new ErrorResponse(errorCode.getStatus().value(), errorCode.getMessage()),
+                errorCode.getStatus()
+        );
+    }
+
+    private ResponseEntity<ErrorResponse> createResponseEntity(ErrorCode errorCode, String message) {
+        return new ResponseEntity<>(
+                new ErrorResponse(errorCode.getStatus().value(), message),
+                errorCode.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/terning/farewell_server/global/success/GlobalSuccessCode.java
+++ b/src/main/java/com/terning/farewell_server/global/success/GlobalSuccessCode.java
@@ -1,0 +1,20 @@
+package com.terning.farewell_server.global.success;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalSuccessCode implements SuccessCode {
+    OK(HttpStatus.OK, "요청이 성공적으로 처리되었습니다."),
+    CREATED(HttpStatus.CREATED, "%s가 성공적으로 생성되었습니다.");
+
+    private final HttpStatus status;
+    private final String rawMessage;
+
+    @Override
+    public String getMessage() {
+        return rawMessage;
+    }
+}

--- a/src/main/java/com/terning/farewell_server/global/success/SuccessCode.java
+++ b/src/main/java/com/terning/farewell_server/global/success/SuccessCode.java
@@ -1,0 +1,12 @@
+package com.terning.farewell_server.global.success;
+
+import org.springframework.http.HttpStatus;
+
+public interface SuccessCode {
+    HttpStatus getStatus();
+    String getMessage();
+
+    default String getMessage(Object... args) {
+        return String.format(this.getMessage(), args);
+    }
+}

--- a/src/main/java/com/terning/farewell_server/global/success/SuccessResponse.java
+++ b/src/main/java/com/terning/farewell_server/global/success/SuccessResponse.java
@@ -1,0 +1,18 @@
+package com.terning.farewell_server.global.success;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public record SuccessResponse<T>(
+        int status,
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        T result
+) {
+    public static <T> SuccessResponse<T> of(SuccessCode successCode, T result) {
+        return new SuccessResponse<>(successCode.getStatus().value(), successCode.getMessage(), result);
+    }
+
+    public static <T> SuccessResponse<T> from(SuccessCode successCode) {
+        return new SuccessResponse<>(successCode.getStatus().value(), successCode.getMessage(), null);
+    }
+}

--- a/src/main/java/com/terning/farewell_server/mail/application/EmailService.java
+++ b/src/main/java/com/terning/farewell_server/mail/application/EmailService.java
@@ -1,5 +1,7 @@
 package com.terning.farewell_server.mail.application;
 
+import com.terning.farewell_server.mail.exception.MailErrorCode;
+import com.terning.farewell_server.mail.exception.MailException;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -41,7 +43,7 @@ public class EmailService {
             log.info("이메일 발송 성공! 수신자: {}, 제목: {}", toEmail, subject);
         } catch (MessagingException e) {
             log.error("이메일 발송 실패. 수신자: {}", toEmail, e);
-            throw new RuntimeException("이메일 발송에 실패했습니다.", e);
+            throw new MailException(MailErrorCode.EMAIL_SEND_FAILURE);
         }
     }
 }

--- a/src/main/java/com/terning/farewell_server/mail/exception/MailErrorCode.java
+++ b/src/main/java/com/terning/farewell_server/mail/exception/MailErrorCode.java
@@ -1,0 +1,27 @@
+package com.terning.farewell_server.mail.exception;
+
+import com.terning.farewell_server.global.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MailErrorCode implements ErrorCode {
+    EMAIL_SEND_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다.");
+
+    private static final String PREFIX = "[MAIL ERROR] ";
+
+    private final HttpStatus status;
+    private final String rawMessage;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return PREFIX + rawMessage;
+    }
+}

--- a/src/main/java/com/terning/farewell_server/mail/exception/MailException.java
+++ b/src/main/java/com/terning/farewell_server/mail/exception/MailException.java
@@ -1,0 +1,11 @@
+package com.terning.farewell_server.mail.exception;
+
+import com.terning.farewell_server.global.error.BaseException;
+import com.terning.farewell_server.global.error.ErrorCode;
+
+public class MailException extends BaseException {
+
+    public MailException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
# 🚀 작업 내용

- AuthController 응답 타입 단순화 (ResponseEntity 제거, void 반환)
- VerificationCodeManager 인증 코드 검증 로직 개선 및 예외 처리 추가
- AuthErrorCode, AuthException 추가
- 글로벌 에러 처리 모듈(BaseException, ErrorCode, ErrorResponse, GlobalErrorCode, GlobalExceptionHandler) 추가
- 글로벌 성공 응답 처리 모듈(GlobalResponseAdvice, GlobalSuccessCode, SuccessCode, SuccessResponse) 추가
- 메일 예외 처리 모듈(MailErrorCode, MailException) 추가 및 EmailService 수정
- AuthControllerTest 개선 (@MockBean 제거, 표준 응답 구조 반영, 실패 케이스 추가)

# 💬 리뷰 중점 사항

- 글로벌 에러/성공 응답 처리 구조가 현재 아키텍처와 잘 맞는지
- 예외 코드 네이밍이 직관적인지 (AuthErrorCode, MailErrorCode, GlobalErrorCode)
- ResponseBodyAdvice 적용 범위를 더 좁히는 게 좋을지 여부

## 📸 Test Screenshot
<img width="360" height="148" alt="스크린샷 2025-08-22 오후 1 33 45" src="https://github.com/user-attachments/assets/c20ff070-f839-43cc-86fd-77afc33cc1b1" />


## 📝 Additional Description

<!-- 추가적인 설명이나 고려사항이 있다면 작성하세요 -->

## 🔗 Related Links

- https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-controller/ann-advice.html#ann-responsebodyadvice
- https://reflectoring.io/spring-boot-exception-handling/


# 📋 연관 이슈

- close #19 