### PR TITLE
[REFACTOR] EventConsumer 예외 발생 테스트가 통과하도록 수정

### DIFF
--- a/src/test/java/com/terning/farewell_server/event/application/EventConsumerTest.java
+++ b/src/test/java/com/terning/farewell_server/event/application/EventConsumerTest.java
@@ -10,6 +10,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -31,6 +32,7 @@ class EventConsumerTest {
     private EventConsumer eventConsumer;
 
     private static final String EMAIL = "test@example.com";
+    private static final String OTHER_PARAM = "someValue";
 
     @Test
     @DisplayName("Kafka 메시지 수신 시, 신청 내역 저장과 이메일 발송이 순서대로 호출된다.")
@@ -40,7 +42,7 @@ class EventConsumerTest {
         doNothing().when(emailService).sendConfirmationEmail(EMAIL);
 
         // when
-        eventConsumer.handleApplication(EMAIL);
+        eventConsumer.handleApplication(EMAIL, OTHER_PARAM);
 
         // then
         InOrder inOrder = inOrder(applicationService, emailService);
@@ -55,8 +57,9 @@ class EventConsumerTest {
         doThrow(new RuntimeException("DB 저장 실패"))
                 .when(applicationService).saveApplication(EMAIL);
 
-        // when
-        eventConsumer.handleApplication(EMAIL);
+        assertThrows(RuntimeException.class, () -> {
+            eventConsumer.handleApplication(EMAIL, OTHER_PARAM);
+        });
 
         // then
         verify(applicationService, times(1)).saveApplication(EMAIL);


### PR DESCRIPTION
## 📝 작업 내용

  - **`EventConsumerTest`의 예외 발생 테스트 로직 수정**
      - 기존에는 의도된 예외를 처리하지 못해 실패하던 테스트를 `assertThrows`를 사용하여 예상된 예외가 발생하는지 검증하도록 변경했습니다.
  - **메소드 시그니처 변경사항 테스트 코드에 반영**
      - `EventConsumer`의 `handleApplication` 메소드에 파라미터가 추가됨에 따라, 테스트 코드의 메소드 호출 부분도 이에 맞게 수정했습니다.

## 🤔 고민한 부분

  - **문제점: 테스트는 왜 실패했는가?**

      - DB 저장 실패 상황을 시뮬레이션하기 위해 `doThrow()`로 예외를 발생시키는 것까지는 좋았지만, 테스트 코드(`@Test`) 내에서 이 예외를 따로 처리하는 로직이 없었습니다. JUnit은 처리되지 않은 예외가 발생하면 해당 테스트를 '실패'로 간주하기 때문에, 로직의 의도와는 다르게 테스트 결과가 실패로 나타났습니다.

  - **해결 방안: 왜 `assertThrows`를 사용했는가?**

      - 이 테스트의 핵심은 '예외가 발생했음을 보장'하고, '예외 발생 후 특정 메소드가 호출되지 않았음을 검증'하는 것입니다.
      - `assertThrows`는 이 두 가지 목적을 완벽하게 만족시키는 JUnit 5의 표준적인 기능입니다. `assertThrows` 블록을 통해 예상된 예외가 발생하는 것을 명시적으로 확인할 수 있으며, 예외를 잡아주기 때문에 테스트가 중단되지 않고 이후의 `verify()` 검증 로직까지 실행될 수 있습니다. 이를 통해 시나리오 전체를 정확하게 테스트하고 성공시킬 수 있었습니다.

# 📋 연관 이슈

- close #28 