### PR TITLE
[REFACTOR] `@WebMvcTest` 컨텍스트 로딩 오류 해결 및 설정 분리

### DIFF
--- a/src/main/java/com/terning/farewell_server/FarewellServerApplication.java
+++ b/src/main/java/com/terning/farewell_server/FarewellServerApplication.java
@@ -2,9 +2,7 @@ package com.terning.farewell_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class FarewellServerApplication {
 

--- a/src/main/java/com/terning/farewell_server/auth/jwt/SecurityConfig.java
+++ b/src/main/java/com/terning/farewell_server/auth/jwt/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.terning.farewell_server.auth.jwt;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,6 +9,11 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
@@ -16,21 +22,37 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    @Value("${cors.allowed-origins}")
+    private String[] allowedOrigins;
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOrigins(Arrays.asList(allowedOrigins));
+
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
-
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/event/**").authenticated()
                         .anyRequest().authenticated()
                 )
-
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
-
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/terning/farewell_server/global/config/JpaConfig.java
+++ b/src/main/java/com/terning/farewell_server/global/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.terning.farewell_server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/test/java/com/terning/farewell_server/auth/api/AuthControllerTest.java
+++ b/src/test/java/com/terning/farewell_server/auth/api/AuthControllerTest.java
@@ -23,10 +23,11 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.Mockito.when;
+
 
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)


### PR DESCRIPTION
# 🚀 작업 내용

  - **`SecurityConfig`**:
      - CORS 허용 도메인을 `application.yml`에서 `@Value`로 주입받아 동적으로 설정하도록 변경했습니다.
      - `SecurityFilterChain`에 이 동적 CORS 설정을 적용했습니다.
  - **`FarewellServerApplication`**:
      - 애플리케이션의 메인 클래스에 있던 `@EnableJpaAuditing` 어노테이션을 제거했습니다.
  - **`JpaConfig`**:
      - JPA Auditing 기능만을 담당하는 별도의 `@Configuration` 클래스를 생성하고, 여기에 `@EnableJpaAuditing` 어노테이션을 이동시켰습니다.

# 💬 리뷰 중점 사항

 - `@WebMvcTest`가 JPA 관련 빈을 로드하여 `JPA metamodel must not be empty` 오류가 발생하던 문제를 해결하는 과정이었습니다.
  - `@EnableJpaAuditing`을 분리하고, `@WebMvcTest`의 설정을 간소화하여 테스트가 웹 계층에만 집중하도록 만들었습니다.
  - **리뷰 요청**: 이와 같은 접근 방식이 `@WebMvcTest`를 활용한 단위 테스트의 모범 사례에 부합하는지 확인해주시면 감사하겠습니다.

#### 2\. 관심사 분리 (설정 리팩토링)

  - `@EnableJpaAuditing`을 메인 애플리케이션 클래스에서 별도의 `JpaConfig`로 분리하여 설정의 의도를 명확히 했습니다.
  - 이러한 분리를 통해 프로덕션 코드의 응집성을 높이고, 특정 기능이 필요한 환경에서만 선택적으로 설정할 수 있는 유연성을 확보했습니다.

#### 3\. 보안 설정 유연성

  - `SecurityConfig`에서 CORS 허용 도메인을 환경 변수로 관리하도록 개선했습니다.
  - **리뷰 요청**: 이 방식이 개발, 테스트, 배포 등 다양한 환경에서 CORS 정책을 유연하게 관리하는 데 효과적인지 검토 부탁드립니다. 특히, 보안 관련 설정이므로 더 나은 방법이 있다면 피드백 주시면 감사하겠습니다.

## 📸 Test Screenshot

<img width="431" height="265" alt="스크린샷 2025-08-25 오후 5 42 13" src="https://github.com/user-attachments/assets/a82ea031-940f-40c5-a1c1-d15df34e2697" />


# 📋 연관 이슈

- close #34 

