### PR TITLE
[FEAT] 관리자용 이벤트 재고 설정 API 구현

### DIFF
--- a/src/main/java/com/terning/farewell_server/auth/jwt/SecurityConfig.java
+++ b/src/main/java/com/terning/farewell_server/auth/jwt/SecurityConfig.java
@@ -52,7 +52,8 @@ public class SecurityConfig {
                                 "/js/**",
                                 "/images/**",
                                 "/api/auth/**",
-                                "/actuator/**"
+                                "/actuator/**",
+                                "/api/admin/**"
                         ).permitAll()
                         .requestMatchers("/api/event/**").authenticated()
                         .anyRequest().authenticated()

--- a/src/main/java/com/terning/farewell_server/event/api/EventAdminController.java
+++ b/src/main/java/com/terning/farewell_server/event/api/EventAdminController.java
@@ -1,0 +1,33 @@
+package com.terning.farewell_server.event.api;
+
+import com.terning.farewell_server.event.application.EventAdminService;
+import com.terning.farewell_server.event.dto.request.SetStockRequest;
+import com.terning.farewell_server.event.dto.response.SetStockResponse;
+import com.terning.farewell_server.event.success.EventSuccessCode;
+import com.terning.farewell_server.global.success.SuccessResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/event")
+public class EventAdminController {
+
+    private final EventAdminService eventAdminService;
+
+    @PostMapping("/stock")
+    public ResponseEntity<SuccessResponse<SetStockResponse>> setEventStock(
+            @Valid @RequestBody SetStockRequest request) {
+
+        int newStock = eventAdminService.setEventStock(request);
+
+        return ResponseEntity
+                .status(EventSuccessCode.SET_EVENT_STOCK_SUCCESS.getStatus())
+                .body(SuccessResponse.of(EventSuccessCode.SET_EVENT_STOCK_SUCCESS, SetStockResponse.from(newStock)));
+    }
+}

--- a/src/main/java/com/terning/farewell_server/event/application/EventAdminService.java
+++ b/src/main/java/com/terning/farewell_server/event/application/EventAdminService.java
@@ -1,0 +1,26 @@
+package com.terning.farewell_server.event.application;
+
+import com.terning.farewell_server.event.dto.request.SetStockRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EventAdminService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${event.gift-stock-key}")
+    private String giftStockKey;
+
+    public int setEventStock(SetStockRequest request) {
+        int count = request.count();
+        redisTemplate.opsForValue().set(giftStockKey, String.valueOf(count));
+        log.info("이벤트 재고가 관리자에 의해 설정되었습니다. 총 재고: {}개", count);
+        return count;
+    }
+}

--- a/src/main/java/com/terning/farewell_server/event/dto/request/SetStockRequest.java
+++ b/src/main/java/com/terning/farewell_server/event/dto/request/SetStockRequest.java
@@ -1,0 +1,10 @@
+package com.terning.farewell_server.event.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record SetStockRequest(
+        @NotNull(message = "재고 수량은 필수입니다.")
+        @Min(value = 0, message = "재고는 0 이상이어야 합니다.")
+        Integer count
+) {}

--- a/src/main/java/com/terning/farewell_server/event/dto/response/EventApplicationResponse.java
+++ b/src/main/java/com/terning/farewell_server/event/dto/response/EventApplicationResponse.java
@@ -1,7 +1,0 @@
-package com.terning.farewell_server.event.dto.response;
-
-public record EventApplicationResponse(String message) {
-    public static EventApplicationResponse from(String message) {
-        return new EventApplicationResponse(message);
-    }
-}

--- a/src/main/java/com/terning/farewell_server/event/dto/response/SetStockResponse.java
+++ b/src/main/java/com/terning/farewell_server/event/dto/response/SetStockResponse.java
@@ -1,0 +1,13 @@
+package com.terning.farewell_server.event.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record SetStockResponse(String message, int stock) {
+    public static SetStockResponse from(int stock) {
+        return SetStockResponse.builder()
+                .message("이벤트 재고가 " + stock + "개로 설정되었습니다.")
+                .stock(stock)
+                .build();
+    }
+}

--- a/src/main/java/com/terning/farewell_server/event/exception/EventErrorCode.java
+++ b/src/main/java/com/terning/farewell_server/event/exception/EventErrorCode.java
@@ -9,12 +9,12 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum EventErrorCode implements ErrorCode {
     APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이메일로 등록된 신청 내역이 없습니다."),
-
     EVENT_CLOSED(HttpStatus.CONFLICT, "아쉽지만 선착순 마감되었습니다."),
     ALREADY_PROCESSING_REQUEST(HttpStatus.CONFLICT, "현재 다른 요청을 처리 중입니다. 잠시 후 다시 시도해주세요."),
-
     GIFT_STOCK_INFO_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "선물 재고 정보를 가져올 수 없습니다."),
-    LOCK_ACQUISITION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "락을 획득하는 동안 문제가 발생했습니다.");
+    LOCK_ACQUISITION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "락을 획득하는 동안 문제가 발생했습니다."),
+
+    INVALID_ADMIN_KEY(HttpStatus.FORBIDDEN, "유효하지 않은 관리자 키입니다. 접근이 거부되었습니다.");
 
     private static final String PREFIX = "[EVENT ERROR] ";
 

--- a/src/main/java/com/terning/farewell_server/event/success/EventSuccessCode.java
+++ b/src/main/java/com/terning/farewell_server/event/success/EventSuccessCode.java
@@ -9,7 +9,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum EventSuccessCode implements SuccessCode {
     GET_EVENT_STATUS_SUCCESS(HttpStatus.OK, "이벤트 신청 상태 조회를 성공했습니다."),
-    EVENT_APPLICATION_ACCEPTED(HttpStatus.ACCEPTED, "신청이 정상적으로 접수되었습니다. 최종 결과는 이메일로 안내됩니다.");
+    EVENT_APPLICATION_ACCEPTED(HttpStatus.ACCEPTED, "신청이 정상적으로 접수되었습니다. 최종 결과는 이메일로 안내됩니다."),
+
+    SET_EVENT_STOCK_SUCCESS(HttpStatus.OK, "이벤트 재고 설정에 성공했습니다.");
+
 
     private final HttpStatus status;
     private final String rawMessage;

--- a/src/main/java/com/terning/farewell_server/global/config/AdminAuthInterceptor.java
+++ b/src/main/java/com/terning/farewell_server/global/config/AdminAuthInterceptor.java
@@ -1,0 +1,35 @@
+package com.terning.farewell_server.global.config;
+
+import com.terning.farewell_server.event.exception.EventErrorCode;
+import com.terning.farewell_server.event.exception.EventException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AdminAuthInterceptor implements HandlerInterceptor {
+
+    @Value("${admin.secret-key}")
+    private String adminSecretKey;
+
+    @Value("${admin.header-name}")
+    private String adminHeaderName;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String secretKey = request.getHeader(adminHeaderName);
+
+        if (secretKey != null && secretKey.equals(adminSecretKey)) {
+            return true;
+        }
+
+        log.warn("관리자 API 접근 실패: 유효하지 않은 Secret Key 입니다. (헤더: {})", adminHeaderName);
+        throw new EventException(EventErrorCode.INVALID_ADMIN_KEY);
+    }
+}

--- a/src/main/java/com/terning/farewell_server/global/config/WebConfig.java
+++ b/src/main/java/com/terning/farewell_server/global/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.terning.farewell_server.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AdminAuthInterceptor adminAuthInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(adminAuthInterceptor)
+                .addPathPatterns("/api/admin/**");
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,7 +6,6 @@ spring:
     url: ${DATASOURCE_URL}
     username: ${DATASOURCE_USERNAME}
     password: ${DATASOURCE_PASSWORD}
-
   jpa:
     hibernate:
       ddl-auto: update
@@ -15,12 +14,10 @@ spring:
         format_sql: true
         default_batch_fetch_size: 100
     open-in-view: false
-
   data:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
-
   mail:
     host: smtp.gmail.com
     port: 587
@@ -32,7 +29,6 @@ spring:
           auth: true
           starttls:
             enable: true
-
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
     producer:
@@ -44,13 +40,16 @@ spring:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
-
 redisson:
   file: classpath:redisson-config.yml
 
 event:
   gift-stock-key: "event:gift:stock"
   kafka-topic: "event-application"
+
+admin:
+  secret-key: ${ADMIN_SECRET_KEY}
+  header-name: "X-ADMIN-KEY"
 
 jwt:
   secret:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -33,7 +33,7 @@ spring:
       group-id: farewell-group-prod
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-serializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
   mail:
     host: smtp.gmail.com
     port: 587

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,13 +7,11 @@ spring:
   config:
     activate:
       on-profile: prod
-
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DATASOURCE_URL}
     username: ${DATASOURCE_USERNAME}
     password: ${DATASOURCE_PASSWORD}
-
   jpa:
     hibernate:
       ddl-auto: validate
@@ -22,12 +20,10 @@ spring:
         format_sql: false
         default_batch_fetch_size: 100
     open-in-view: false
-
   data:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
-
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
     producer:
@@ -37,8 +33,7 @@ spring:
       group-id: farewell-group-prod
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-
+      value-serializer: org.apache.kafka.common.serialization.StringDeserializer
   mail:
     host: smtp.gmail.com
     port: 587
@@ -57,6 +52,10 @@ redisson:
 event:
   gift-stock-key: "event:gift:stock:prod"
   kafka-topic: "event-application-prod"
+
+admin:
+  secret-key: ${ADMIN_SECRET_KEY}
+  header-name: "X-ADMIN-KEY"
 
 jwt:
   secret:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -15,9 +15,6 @@ spring:
         format_sql: true
     open-in-view: true
 
-  # data:
-  #   redis:
-
   mail:
     host: localhost
     port: 25
@@ -36,6 +33,10 @@ spring:
 event:
   gift-stock-key: "event:gift:stock:test"
   kafka-topic: "event-application-test"
+
+admin:
+  secret-key: "test-secret-key"
+  header-name: "X-ADMIN-KEY"
 
 jwt:
   secret:

--- a/src/test/java/com/terning/farewell_server/event/api/EventAdminControllerTest.java
+++ b/src/test/java/com/terning/farewell_server/event/api/EventAdminControllerTest.java
@@ -1,0 +1,107 @@
+package com.terning.farewell_server.event.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.terning.farewell_server.event.application.EventAdminService;
+import com.terning.farewell_server.event.dto.request.SetStockRequest;
+import com.terning.farewell_server.util.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class EventAdminControllerTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private EventAdminService eventAdminService;
+
+    @Value("${admin.secret-key}")
+    private String adminSecretKey;
+
+    @Value("${admin.header-name}")
+    private String adminHeaderName;
+
+    @Nested
+    @DisplayName("POST /api/admin/event/stock - 이벤트 재고 설정 API 테스트")
+    class SetEventStockTest {
+
+        private final String BASE_URL = "/api/admin/event/stock";
+
+        @Test
+        @DisplayName("성공: 유효한 요청과 인증 키로 재고 설정에 성공하고 200 OK를 반환한다.")
+        void setEventStock_Success() throws Exception {
+            // given
+            int stockCount = 100;
+            SetStockRequest request = new SetStockRequest(stockCount);
+            String requestBody = objectMapper.writeValueAsString(request);
+
+            when(eventAdminService.setEventStock(any(SetStockRequest.class))).thenReturn(stockCount);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post(BASE_URL)
+                    .header(adminHeaderName, adminSecretKey)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody));
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.message").value("이벤트 재고 설정에 성공했습니다."))
+                    .andExpect(jsonPath("$.result.stock").value(stockCount));
+        }
+
+        @Test
+        @DisplayName("실패: 인증 키가 없으면 403 Forbidden을 반환한다.")
+        void setEventStock_Fail_NoAuthKey() throws Exception {
+            // given
+            SetStockRequest request = new SetStockRequest(100);
+            String requestBody = objectMapper.writeValueAsString(request);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post(BASE_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody));
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message").value("[EVENT ERROR] 유효하지 않은 관리자 키입니다. 접근이 거부되었습니다."));
+        }
+
+        @Test
+        @DisplayName("실패: 재고 수량이 음수이면 400 Bad Request를 반환한다.")
+        void setEventStock_Fail_NegativeStock() throws Exception {
+            // given
+            SetStockRequest request = new SetStockRequest(-1);
+            String requestBody = objectMapper.writeValueAsString(request);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post(BASE_URL)
+                    .header(adminHeaderName, adminSecretKey)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody));
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("'count' 필드: 재고는 0 이상이어야 합니다."));
+        }
+    }
+}

--- a/src/test/java/com/terning/farewell_server/event/application/EventAdminServiceTest.java
+++ b/src/test/java/com/terning/farewell_server/event/application/EventAdminServiceTest.java
@@ -1,0 +1,53 @@
+package com.terning.farewell_server.event.application;
+
+import com.terning.farewell_server.event.dto.request.SetStockRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventAdminServiceTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private EventAdminService eventAdminService;
+
+    private final String MOCK_GIFT_STOCK_KEY = "event:gift:stock:test";
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(eventAdminService, "giftStockKey", MOCK_GIFT_STOCK_KEY);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    @DisplayName("이벤트 재고 설정 요청 시, Redis에 정확한 키와 값으로 저장되어야 한다.")
+    void setEventStock_Success() {
+        // given
+        int stockCount = 100;
+        SetStockRequest request = new SetStockRequest(stockCount);
+
+        // when
+        int result = eventAdminService.setEventStock(request);
+
+        // then
+        verify(valueOperations, times(1)).set(MOCK_GIFT_STOCK_KEY, String.valueOf(stockCount));
+
+        assertThat(result).isEqualTo(stockCount);
+    }
+}

--- a/src/test/java/com/terning/farewell_server/util/IntegrationTestSupport.java
+++ b/src/test/java/com/terning/farewell_server/util/IntegrationTestSupport.java
@@ -1,5 +1,6 @@
 package com.terning.farewell_server.util;
 
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -11,6 +12,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 @ActiveProfiles("test")
+@AutoConfigureMockMvc
 @Testcontainers
 @SpringBootTest
 public abstract class IntegrationTestSupport {


### PR DESCRIPTION
# 🚀 작업 내용

- **관리자용 이벤트 재고 설정 API를 구현했습니다.**
  - `POST /api/admin/event/stock` 엔드포인트를 통해 이벤트의 선착순 재고를 동적으로 설정할 수 있습니다.
- **Secret Key 기반의 관리자 인증을 구현했습니다.**
  - `AdminAuthInterceptor`를 도입하여 `X-ADMIN-KEY` 헤더를 검증하는 방식으로 관리자 API를 보호합니다.
- **기능(도메인) 중심의 패키지 구조를 적용했습니다.**
  - 관리자 기능이지만 핵심 비즈니스가 '이벤트'에 속하므로, 관련 코드를 모두 `event` 패키지 내에 구성하여 응집도를 높였습니다.

# 💬 리뷰 중점 사항

이번 작업을 진행하며 다음과 같은 점들을 주로 고민하고 결정했습니다.

### 1. 관리자 인증 방식 선택
**고민**: 관리자 인증을 어떻게 할 것인가? 기존 사용자용 JWT 시스템을 확장할까, 아니면 더 간단한 방식을 사용할까?
**결정**: 별도의 관리자 로그인 페이지 없이, 백엔드 간 통신이나 내부 도구(Postman 등)에서 사용하기 편리하도록 **정적 Secret Key 방식**을 채택했습니다. 이는 `AdminAuthInterceptor`를 통해 구현하여 인증 로직을 컨트롤러로부터 분리하고, 향후 다른 관리자 API가 추가될 때 재사용할 수 있도록 설계했습니다.

### 2. 패키지 구조 설계
**고민**: 관리자 코드를 별도의 `admin` 패키지로 분리할까, 아니면 기능의 응집도를 위해 관련 도메인인 `event` 패키지에 포함시킬까?
**결정**: 기능(도메인) 중심의 패키지 구조가 유지보수성과 응집도 측면에서 더 유리하다고 판단하여, **`EventAdminController`와 관련 클래스들을 `event` 패키지 내에 구성**했습니다. 관리자 API라는 것은 '역할'일 뿐, 핵심 비즈니스는 '이벤트'에 속하기 때문에, 관련된 모든 코드를 한곳에 모아두는 것이 더 직관적이라고 생각했습니다.

## 📸 Test Screenshot
<img width="491" height="435" alt="스크린샷 2025-08-28 오후 1 55 34" src="https://github.com/user-attachments/assets/7076f04a-4dd9-4343-8cd3-af316a7a15f7" />

<img width="299" height="319" alt="스크린샷 2025-08-28 오후 1 55 51" src="https://github.com/user-attachments/assets/7d8761e8-acdc-4a92-9c5f-2277cfc31263" />

# 📋 연관 이슈

- close #56 



