### PR TITLE
백엔드 CD 파이프라인에 프론트엔드 배포 자동화 추가

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -8,7 +8,6 @@ jobs:
   build-and-push:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
-
     steps:
       - name: 체크아웃
         uses: actions/checkout@v4
@@ -43,10 +42,8 @@ jobs:
       - name: Docker 이미지 빌드 및 푸시
         run: |
           GIT_TAG=$(git rev-parse --short HEAD)
-
           docker build --platform linux/amd64 -t jsoonworld/terning-farewell-server:$GIT_TAG .
           docker push jsoonworld/terning-farewell-server:$GIT_TAG
-
           docker tag jsoonworld/terning-farewell-server:$GIT_TAG jsoonworld/terning-farewell-server:latest
           docker push jsoonworld/terning-farewell-server:latest
 
@@ -56,7 +53,36 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: docker 컨테이너 실행
+      - name: 프론트엔드 소스 코드 체크아웃
+        uses: actions/checkout@v4
+        with:
+          repository: terning-farewell-thanks/terning-farewell-client
+          path: client
+
+      - name: Node.js 20.x 버전 설정
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: client/package-lock.json
+
+      - name: 프론트엔드 의존성 설치 및 빌드
+        run: |
+          cd client
+          npm install
+          npm run build
+
+      - name: EC2 서버에 프론트엔드 dist 폴더 업로드
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SERVER_IP }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_KEY }}
+          source: "client/dist"
+          target: "/home/ubuntu"
+          rm: true
+
+      - name: Docker 컨테이너 실행
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.SERVER_IP }}


### PR DESCRIPTION
# 🚀 작업 내용

- **기존 백엔드 CD 파이프라인에 프론트엔드 배포 자동화 로직을 추가했습니다.**
  - 이제 `main` 브랜치에 코드가 푸시되면, GitHub Actions가 자동으로 다음을 수행합니다:
    1. 최신 프론트엔드 코드를 빌드하여 `dist` 폴더를 생성합니다.
    2. `scp`를 사용해 생성된 `dist` 폴더를 EC2 서버에 안전하게 전송합니다.
    3. 기존 `deploy.sh` 스크립트를 실행하여 백엔드 컨테이너를 재시작합니다.
# 💬 리뷰 중점 사항

**고민**: 기존에는 백엔드 배포와 프론트엔드 배포가 분리되어 있어, 백엔드 CI/CD 실행 후 프론트엔드 배포를 잊거나 실수하는 경우가 잦았습니다. 이로 인해 `index.html`이 참조하는 에셋 파일이 서버에 존재하지 않는 **버전 불일치 문제가 반복적으로 발생**했습니다.

**해결**: 이 문제를 근본적으로 해결하기 위해, **백엔드 배포 플로우에 프론트엔드 배포를 통합**했습니다. 이제 단일 트리거(`main` 브랜치 푸시)를 통해 프론트엔드와 백엔드가 항상 일관된 최신 상태로 함께 배포되므로, **수동 배포로 인한 실수를 원천적으로 차단**할 수 있습니다.

특히 `scp-action`의 `rm: true` 옵션을 사용하여, 서버의 기존 `dist` 폴더를 깨끗하게 삭제한 후 새로 업로드하도록 구성했습니다. 이를 통해 오래된 빌드 파일이 남아있는 문제를 방지합니다.



# 📋 연관 이슈

- close #59 
