### PR TITLE
[FIX] CD 워크플로우의 프론트엔드 레포지토리 접근 오류 수정

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           repository: terning-farewell-thanks/terning-farewell-client
           path: client
+          token: ${{ secrets.GH_PAT }} 
 
       - name: Node.js 20.x 버전 설정
         uses: actions/setup-node@v4


### PR DESCRIPTION
# 🚀 작업 내용

- 백엔드 CD 워크플로우(`.github/workflows/DOCKER-CD.yml`)가 비공개 프론트엔드 레포지토리를 체크아웃할 때 발생하는 인증 오류를 수정했습니다.
- `actions/checkout` 스텝에 Personal Access Token(PAT)을 사용하도록 `token: ${{ secrets.GH_PAT }}` 옵션을 추가했습니다.


# 💬 리뷰 중점 사항

- **문제 원인**: GitHub Actions의 기본 `GITHUB_TOKEN`은 해당 레포지토리에만 접근 권한이 있어, 다른 비공개 레포지토리를 클론할 수 없는 문제였습니다.
- **해결 방안**: 이 문제를 해결하기 위해 `repo` 스코프를 가진 PAT를 발급하여 `GH_PAT`라는 이름의 Secret으로 등록하고, 워크플로우가 이 Secret을 사용하도록 하여 안전하게 인증 문제를 해결했습니다.
- 이제 백엔드 CD 파이프라인이 프론트엔드 레포지토리를 정상적으로 클론하여 빌드 및 배포를 수행할 수 있습니다.


# 📋 연관 이슈

- close #59 
