### PR TITLE
[REFACTOR] Kafka 컨슈머의 토픽 불일치 문제 해결

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -55,9 +55,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Copy deployment script to EC2
         uses: appleboy/scp-action@v0.1.7
         with:

--- a/src/main/java/com/terning/farewell_server/event/application/EventConsumer.java
+++ b/src/main/java/com/terning/farewell_server/event/application/EventConsumer.java
@@ -21,14 +21,12 @@ public class EventConsumer {
     private final ApplicationService applicationService;
     private final EmailService emailService;
 
-    private static final String KAFKA_TOPIC = "event-application";
-
     @RetryableTopic(
             attempts = "3",
             backoff = @Backoff(delay = 1000, multiplier = 2),
             dltStrategy = DltStrategy.FAIL_ON_ERROR
     )
-    @KafkaListener(topics = KAFKA_TOPIC)
+    @KafkaListener(topics = "${event.kafka-topic}")
     public void handleApplication(String email, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         log.info("Kafka 메시지 수신 [Topic: {}]: {}", topic, email);
         applicationService.saveApplication(email);


### PR DESCRIPTION
# 🚀 작업 내용

-   **1. 하드코딩된 Kafka 컨슈머 토픽 이름 수정**
    -   기존에 `EventConsumer` 클래스 내부에 `"event-application"`으로 하드코딩되어 있던 Kafka 토픽 이름을 삭제했습니다.
    -   `@KafkaListener` 어노테이션이 `application.yml`에 정의된 `event.kafka-topic` 프로퍼티(`event-application-prod`)를 직접 참조하도록 변경하여, 프로듀서와 컨슈머가 사용하는 토픽 이름을 일치시켰습니다.

# 💬 리뷰 중점 사항

-   `EventConsumer`의 `@KafkaListener`가 프로듀서와 동일하게 `event.kafka-topic` 프로퍼티를 올바르게 참조하고 있는지 확인 부탁드립니다.
-   이번 수정을 통해 이벤트 신청 후 최종적으로 DB에 데이터가 저장되는 비동기 흐름이 정상적으로 동작하는지 중점적으로 봐주시면 좋겠습니다.
-   추가적으로, 코드 내에 다른 하드코딩된 설정값이 남아있는지 확인하면 좋을 것 같습니다.

## 📸 Test Screenshot

<img width="374" height="317" alt="스크린샷 2025-09-05 오후 3 47 15" src="https://github.com/user-attachments/assets/7cdf98af-6d36-4cdf-ba12-7344d702d046" />


# 📋 연관 이슈

-   close #86 