### PR TITLE
[FEAT] 선착순 이벤트 신청 성공/실패 처리 로직 구현 및 동시성 테스트 환경 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,10 @@ HELP.md
 
 # virtual machine crash logs
 hs_err_pid*
+
+# =================================================
+# Generated test files
+# =================================================
+
+# Performance test JWT tokens
+performance/tokens.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,38 @@
 version: '3.8'
 
 services:
+  # ------------------ Database ------------------
+  mysql:
+    image: mysql:8.0
+    container_name: mysql
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_DATABASE: terning_farewell_local
+      MYSQL_USER: root
+      MYSQL_PASSWORD: Dpvmzlffk1!
+      MYSQL_ROOT_PASSWORD: Dpvmzlffk1!
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - ./data/mysql:/var/lib/mysql
+
+  # ------------------ In-Memory Cache ------------------
+  redis:
+    image: redis:latest
+    container_name: redis
+    ports:
+      - "6379:6379"
+
+  # ------------------ Message Queue ------------------
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.3
     container_name: zookeeper
     ports:
       - "2181:2181"
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKeeper_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
@@ -24,3 +49,11 @@ services:
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
+  # ------------------ Email Tester ------------------
+  mailhog:
+    image: mailhog/mailhog
+    container_name: mailhog
+    ports:
+      - "1025:1025" # SMTP Port
+      - "8025:8025" # Web UI Port

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     ports:
       - "2181:2181"
     environment:
-      ZOOKeeper_CLIENT_PORT: 2181
+      ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka:

--- a/performance/event-test.js
+++ b/performance/event-test.js
@@ -1,0 +1,51 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { SharedArray } from 'k6/data';
+
+const BASE_URL = 'http://localhost:8080';
+
+export const options = {
+    scenarios: {
+        event_application_race: {
+            executor: 'per-vu-iterations',
+            vus: 1500,
+            iterations: 1,
+            maxDuration: '1m',
+        },
+    },
+    thresholds: {
+        'http_req_duration': ['p(95)<1500'],
+    },
+};
+
+const tokens = new SharedArray('all-user-tokens', function () {
+    console.log('[Init] Reading tokens from file: ./tokens.txt');
+    try {
+        const f = open('./tokens.txt');
+        return f.split('\n').filter(Boolean);
+    } catch (e) {
+        console.error(`Could not open tokens file. Make sure 'tokens.txt' exists in the script's directory. Error: ${e.message}`);
+        return [];
+    }
+});
+
+export default function () {
+    if (tokens.length < 1500) {
+        console.error('Not enough tokens in tokens.txt. Please generate at least 1500 unique tokens.');
+        return;
+    }
+
+    const token = tokens[__VU - 1];
+
+    const params = {
+        headers: {
+            'Authorization': `Bearer ${token}`,
+        },
+    };
+
+    const applyRes = http.post(`${BASE_URL}/api/event/apply`, null, params);
+
+    check(applyRes, {
+        'Event application processed (status 202 or 409)': (r) => r.status === 202 || r.status === 409,
+    });
+}

--- a/src/main/java/com/terning/farewell_server/application/application/ApplicationService.java
+++ b/src/main/java/com/terning/farewell_server/application/application/ApplicationService.java
@@ -6,21 +6,24 @@ import com.terning.farewell_server.application.domain.ApplicationStatus;
 import com.terning.farewell_server.application.exception.ApplicationErrorCode;
 import com.terning.farewell_server.application.exception.ApplicationException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ApplicationService {
 
     private final ApplicationRepository applicationRepository;
 
     @Transactional
-    public void saveApplication(String email) {
+    public void saveApplication(String email, ApplicationStatus status) {
         if (applicationRepository.existsByEmail(email)) {
+            log.warn("이미 처리된 이벤트 신청입니다. (중복 메시지 수신) Email: {}", email);
             return;
         }
-        Application application = Application.from(email);
+        Application application = Application.from(email, status);
         applicationRepository.save(application);
     }
 

--- a/src/main/java/com/terning/farewell_server/application/domain/Application.java
+++ b/src/main/java/com/terning/farewell_server/application/domain/Application.java
@@ -29,12 +29,12 @@ public class Application extends BaseTimeEntity {
     @Column(nullable = false)
     private ApplicationStatus status;
 
-    private Application(String email) {
+    private Application(String email, ApplicationStatus status) {
         this.email = email;
-        this.status = ApplicationStatus.SUCCESS;
+        this.status = status;
     }
 
-    public static Application from(String email) {
-        return new Application(email);
+    public static Application from(String email, ApplicationStatus status) {
+        return new Application(email, status);
     }
 }

--- a/src/main/java/com/terning/farewell_server/application/domain/ApplicationStatus.java
+++ b/src/main/java/com/terning/farewell_server/application/domain/ApplicationStatus.java
@@ -2,5 +2,5 @@ package com.terning.farewell_server.application.domain;
 
 public enum ApplicationStatus {
     SUCCESS,
-    FAILED
+    FAILURE
 }

--- a/src/main/java/com/terning/farewell_server/event/application/EventService.java
+++ b/src/main/java/com/terning/farewell_server/event/application/EventService.java
@@ -2,6 +2,7 @@ package com.terning.farewell_server.event.application;
 
 import com.terning.farewell_server.application.domain.Application;
 import com.terning.farewell_server.application.domain.ApplicationRepository;
+import com.terning.farewell_server.application.domain.ApplicationStatus;
 import com.terning.farewell_server.event.dto.response.StatusResponse;
 import com.terning.farewell_server.event.exception.EventErrorCode;
 import com.terning.farewell_server.event.exception.EventException;
@@ -76,11 +77,12 @@ public class EventService {
 
             if (remainingStock < 0) {
                 log.info(LOG_EVENT_CLOSED, email);
+                kafkaTemplate.send(kafkaTopic, email + ":" + ApplicationStatus.FAILURE.name());
                 throw new EventException(EventErrorCode.EVENT_CLOSED);
             }
 
             log.info(LOG_EVENT_PASSED, email, remainingStock);
-            kafkaTemplate.send(kafkaTopic, email);
+            kafkaTemplate.send(kafkaTopic, email + ":" + ApplicationStatus.SUCCESS.name());
 
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -18,17 +18,30 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+
   mail:
-    host: smtp.gmail.com
-    port: 587
-    username: ${MAIL_USERNAME}
-    password: ${MAIL_PASSWORD}
+    # --- [로컬 성능 테스트용: MailHog 사용 시] ---
+    host: localhost
+    port: 1025
     properties:
       mail:
         smtp:
-          auth: true
+          auth: false
           starttls:
-            enable: true
+            enable: false
+
+    # --- [개발/배포용: Gmail 등 실제 메일 서버 사용 시] ---
+    # host: smtp.gmail.com
+    # port: 587
+    # username: ${MAIL_USERNAME}
+    # password: ${MAIL_PASSWORD}
+    # properties:
+    #   mail:
+    #     smtp:
+    #       auth: true
+    #       starttls:
+    #         enable: true
+
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
     producer:

--- a/src/test/java/com/terning/farewell_server/application/domain/ApplicationTest.java
+++ b/src/test/java/com/terning/farewell_server/application/domain/ApplicationTest.java
@@ -8,17 +8,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ApplicationTest {
 
     @Test
-    @DisplayName("from 메소드로 Application 객체 생성 시, email과 기본 상태가 올바르게 설정된다.")
-    void createApplication_with_of_method() {
+    @DisplayName("from 메소드로 Application 객체 생성 시, email과 상태가 올바르게 설정된다.")
+    void createApplication_with_from_method() {
         // given
         String expectedEmail = "test@example.com";
+        ApplicationStatus expectedStatus = ApplicationStatus.SUCCESS;
 
         // when
-        Application application = Application.from(expectedEmail);
+        Application application = Application.from(expectedEmail, expectedStatus);
 
         // then
         assertThat(application).isNotNull();
         assertThat(application.getEmail()).isEqualTo(expectedEmail);
-        assertThat(application.getStatus()).isEqualTo(ApplicationStatus.SUCCESS);
+        assertThat(application.getStatus()).isEqualTo(expectedStatus);
     }
 }

--- a/src/test/java/com/terning/farewell_server/auth/jwt/TokenGenerator.java
+++ b/src/test/java/com/terning/farewell_server/auth/jwt/TokenGenerator.java
@@ -1,0 +1,59 @@
+package com.terning.farewell_server.auth.jwt;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TokenGenerator {
+    public static void main(String[] args) throws Exception {
+        String jwtSecretKey = System.getenv("JWT_SECRET_KEY");
+
+        if (jwtSecretKey == null || jwtSecretKey.isBlank()) {
+            System.err.println("오류: JWT_SECRET_KEY 환경 변수가 설정되지 않았습니다.");
+            System.err.println("IntelliJ 실행 설정(Run Configuration)에 환경 변수를 추가해주세요.");
+            return;
+        }
+
+        long jwtExpirationMs = 3600000;
+
+        JwtUtil jwtUtil = new JwtUtil();
+
+        setPrivateField(jwtUtil, "secretKeyString", jwtSecretKey);
+        setPrivateField(jwtUtil, "expirationTime", jwtExpirationMs);
+
+        jwtUtil.init();
+
+        int userCount = 1500;
+        List<String> tokens = new ArrayList<>();
+        System.out.println("Generating " + userCount + " unique tokens...");
+
+        for (int i = 1; i <= userCount; i++) {
+            String email = "testuser_" + i + "@example.com";
+            String token = jwtUtil.generateTemporaryToken(email);
+            tokens.add(token);
+        }
+
+        writeTokensToFile(tokens);
+
+        System.out.println("Successfully created 'performance/tokens.txt' file with " + userCount + " tokens.");
+    }
+
+    private static void setPrivateField(Object target, String fieldName, Object value) throws NoSuchFieldException, IllegalAccessException {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static void writeTokensToFile(List<String> tokens) throws IOException {
+        Path performanceDirPath = Paths.get("performance");
+        if (!Files.exists(performanceDirPath)) {
+            Files.createDirectories(performanceDirPath);
+        }
+        Path filePath = performanceDirPath.resolve("tokens.txt");
+        Files.write(filePath, tokens);
+    }
+}

--- a/src/test/java/com/terning/farewell_server/event/application/EventConsumerTest.java
+++ b/src/test/java/com/terning/farewell_server/event/application/EventConsumerTest.java
@@ -1,6 +1,7 @@
 package com.terning.farewell_server.event.application;
 
 import com.terning.farewell_server.application.application.ApplicationService;
+import com.terning.farewell_server.application.domain.ApplicationStatus;
 import com.terning.farewell_server.mail.application.EmailService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+
 @ExtendWith(MockitoExtension.class)
 class EventConsumerTest {
 
@@ -32,37 +34,55 @@ class EventConsumerTest {
     private EventConsumer eventConsumer;
 
     private static final String EMAIL = "test@example.com";
-    private static final String OTHER_PARAM = "someValue";
+    private static final String TOPIC = "event-application";
 
     @Test
-    @DisplayName("Kafka 메시지 수신 시, 신청 내역 저장과 이메일 발송이 순서대로 호출된다.")
+    @DisplayName("SUCCESS 상태의 Kafka 메시지 수신 시, 신청 내역 저장과 이메일 발송이 순서대로 호출된다.")
     void handleApplication_Success() {
         // given
-        doNothing().when(applicationService).saveApplication(EMAIL);
+        String successMessage = EMAIL + ":" + ApplicationStatus.SUCCESS.name();
+        doNothing().when(applicationService).saveApplication(EMAIL, ApplicationStatus.SUCCESS);
         doNothing().when(emailService).sendConfirmationEmail(EMAIL);
 
         // when
-        eventConsumer.handleApplication(EMAIL, OTHER_PARAM);
+        eventConsumer.handleApplication(successMessage, TOPIC);
 
         // then
         InOrder inOrder = inOrder(applicationService, emailService);
-        inOrder.verify(applicationService, times(1)).saveApplication(EMAIL);
+        inOrder.verify(applicationService, times(1)).saveApplication(EMAIL, ApplicationStatus.SUCCESS);
         inOrder.verify(emailService, times(1)).sendConfirmationEmail(EMAIL);
     }
 
     @Test
-    @DisplayName("신청 내역 저장 중 예외 발생 시, 이메일 발송은 호출되지 않아야 한다.")
+    @DisplayName("FAILURE 상태의 Kafka 메시지 수신 시, 신청 내역만 저장되고 이메일 발송은 호출되지 않는다.")
+    void handleApplication_Failure_Status() {
+        // given
+        String failureMessage = EMAIL + ":" + ApplicationStatus.FAILURE.name();
+        doNothing().when(applicationService).saveApplication(EMAIL, ApplicationStatus.FAILURE);
+
+        // when
+        eventConsumer.handleApplication(failureMessage, TOPIC);
+
+        // then
+        verify(applicationService, times(1)).saveApplication(EMAIL, ApplicationStatus.FAILURE);
+        verify(emailService, never()).sendConfirmationEmail(anyString());
+    }
+
+    @Test
+    @DisplayName("신청 내역 저장 중 예외 발생 시, 런타임 예외를 다시 던져야 한다.")
     void handleApplication_Fail_On_Save() {
         // given
+        String successMessage = EMAIL + ":" + ApplicationStatus.SUCCESS.name();
         doThrow(new RuntimeException("DB 저장 실패"))
-                .when(applicationService).saveApplication(EMAIL);
+                .when(applicationService).saveApplication(EMAIL, ApplicationStatus.SUCCESS);
 
+        // when & then
         assertThrows(RuntimeException.class, () -> {
-            eventConsumer.handleApplication(EMAIL, OTHER_PARAM);
+            eventConsumer.handleApplication(successMessage, TOPIC);
         });
 
         // then
-        verify(applicationService, times(1)).saveApplication(EMAIL);
+        verify(applicationService, times(1)).saveApplication(EMAIL, ApplicationStatus.SUCCESS);
         verify(emailService, never()).sendConfirmationEmail(anyString());
     }
 }


### PR DESCRIPTION
# 📄 작업 내용

기존 선착순 이벤트 신청 시스템의 **성공/실패 처리 로직을 보강**하고, 대규모 트래픽을 대비한 **동시성 테스트 환경을 구축**했습니다.

#### **1. 신청 성공/실패 처리 로직 구현**
- **`ApplicationStatus` 추가**: `Application` 도메인에 신청 결과를 저장하는 `SUCCESS`, `FAILURE` 상태를 추가했습니다.
- **Kafka 메시지 포맷 변경**: Producer(`EventService`)가 `email:STATUS` 형태의 메시지를 발행하도록 변경하여, 재고 유무에 따른 신청 결과를 명시적으로 전달합니다.
- **Consumer 로직 수정**: Consumer(`EventConsumer`)는 `SUCCESS` 상태의 메시지를 수신했을 때만 당첨 안내 메일을 발송하도록 로직을 수정하여 불필요한 메일 발송을 방지합니다.

#### **2. 동시성 테스트 환경 구축**
- **`k6` 테스트 스크립트**: 대규모 가상 유저(Virtual User)가 동시에 이벤트를 신청하는 시나리오의 `k6` 스크립트를 작성했습니다.
- **`TokenGenerator` 유틸리티**: 테스트에 필요한 다수의 JWT를 로컬에서 미리 생성하는 Java 유틸리티를 구현했습니다. 이를 통해 테스트 데이터 생성 로직을 애플리케이션과 분리했습니다.
- **`Docker Compose` 구성**: `Kafka`, `Redis`, `MailHog` 등 테스트에 필요한 인프라를 `Docker Compose`로 통일하여 팀원 모두가 동일한 환경에서 테스트를 실행할 수 있도록 구성했습니다.

# 💬 리뷰 중점 사항

구현을 진행하면서 아래 두 가지 포인트에 대해 특히 많이 고민했습니다. 리뷰 시 이 부분들을 중점적으로 봐주시면 감사하겠습니다.

#### **1. Kafka 메시지 포맷: `단순 문자열` vs `JSON 객체`**
- **고민**: 이벤트 신청 결과를 Consumer에게 전달할 때, `email:STATUS` 형태의 단순한 문자열 조합 방식을 선택했습니다. JSON 객체로 직렬화하여 전달하는 방식도 고려했지만, 현재 필요한 정보가 이메일과 상태 두 가지뿐이라 판단하여 오버헤드가 적은 단순 문자열 방식을 채택했습니다.
- **리뷰 요청**: 이 방식이 장기적인 관점에서 확장성이나 유지보수성에 문제가 없을지, 혹은 지금 단계에서 JSON 구조를 도입하는 것이 더 나을지에 대한 의견이 궁금합니다.

#### **2. 테스트 토큰 발급 방식: `독립 유틸리티` vs `테스트용 API`**
- **고민**: `k6` 스크립트에서 사용할 대량의 토큰을 발급하는 방법으로, ①테스트 전용 API를 구현하는 것과 ②독립적인 Java 유틸리티를 만드는 것을 고민했습니다.
- **리뷰 요청**: 최종적으로 애플리케이션 코드에 테스트용 로직이 포함되는 것을 피하고, 테스트 데이터 생성을 완전히 분리하기 위해 `TokenGenerator` 유틸리티를 만드는 방식을 선택했습니다. 이 구조가 테스트 격리 측면에서 더 적절한 선택이었는지 리뷰 부탁드립니다.


## 📸 Test Screenshot

<img width="1040" height="1344" alt="스크린샷 2025-09-06 오후 6 52 22" src="https://github.com/user-attachments/assets/325d64a9-24d1-4aa3-baba-5b5b9b2fcb71" />


# 📋 연관 이슈

- close #89 
