### PR TITLE
[REFACTOR] EmailService에서 발신자 주소를 명시적으로 설정

### DIFF
--- a/src/main/java/com/terning/farewell_server/mail/application/EmailService.java
+++ b/src/main/java/com/terning/farewell_server/mail/application/EmailService.java
@@ -6,6 +6,7 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
@@ -20,23 +21,22 @@ public class EmailService {
     private final JavaMailSender javaMailSender;
     private final SpringTemplateEngine templateEngine;
 
+    @Value("${spring.mail.from}")
+    private String fromEmail;
+
     private static final String VERIFICATION_EMAIL_SUBJECT = "[터닝] 마지막 선물 신청을 위한 인증 코드입니다.";
     private static final String CONFIRMATION_EMAIL_SUBJECT = "[터닝] 선물 신청이 확정되었습니다.";
 
     public void sendVerificationCode(String toEmail, String code) {
         Context context = new Context();
         context.setVariable("code", code);
-
         String htmlContent = templateEngine.process("verificationCode", context);
-
         sendEmail(toEmail, VERIFICATION_EMAIL_SUBJECT, htmlContent);
     }
 
     public void sendConfirmationEmail(String toEmail) {
         Context context = new Context();
-
         String htmlContent = templateEngine.process("confirmationEmail", context);
-
         sendEmail(toEmail, CONFIRMATION_EMAIL_SUBJECT, htmlContent);
     }
 
@@ -44,6 +44,8 @@ public class EmailService {
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
         try {
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+
+            mimeMessageHelper.setFrom(fromEmail);
             mimeMessageHelper.setTo(toEmail);
             mimeMessageHelper.setSubject(subject);
             mimeMessageHelper.setText(htmlBody, true);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,6 +23,7 @@ spring:
     # --- [로컬 성능 테스트용: MailHog 사용 시] ---
     host: localhost
     port: 1025
+    from: test@example.com
     properties:
       mail:
         smtp:
@@ -33,6 +34,7 @@ spring:
     # --- [개발/배포용: Gmail 등 실제 메일 서버 사용 시] ---
     # host: smtp.gmail.com
     # port: 587
+    # from: your-email@gmail.com
     # username: ${MAIL_USERNAME}
     # password: ${MAIL_PASSWORD}
     # properties:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -18,6 +18,7 @@ spring:
   mail:
     host: localhost
     port: 25
+    from: test@example.com #
     properties:
       mail:
         smtp:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -18,7 +18,7 @@ spring:
   mail:
     host: localhost
     port: 25
-    from: test@example.com #
+    from: test@example.com
     properties:
       mail:
         smtp:

--- a/src/test/java/com/terning/farewell_server/mail/application/EmailServiceTest.java
+++ b/src/test/java/com/terning/farewell_server/mail/application/EmailServiceTest.java
@@ -5,6 +5,7 @@ import com.terning.farewell_server.mail.exception.MailException;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,15 +15,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
+import java.io.IOException;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,17 +45,22 @@ class EmailServiceTest {
     private ArgumentCaptor<MimeMessage> mimeMessageCaptor;
 
     private static final String TO_EMAIL = "test@example.com";
+    private static final String FROM_EMAIL = "noreply@example.com";
     private static final String CODE = "123456";
     private static final String MOCK_HTML_CONTENT = "<html>...</html>";
     private static final String VERIFICATION_EMAIL_SUBJECT = "[터닝] 마지막 선물 신청을 위한 인증 코드입니다.";
     private static final String CONFIRMATION_EMAIL_SUBJECT = "[터닝] 선물 신청이 확정되었습니다.";
 
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(emailService, "fromEmail", FROM_EMAIL);
+    }
+
     @Test
     @DisplayName("인증 코드 이메일을 성공적으로 발송해야 한다.")
-    void sendVerificationCode_should_send_email_successfully() throws MessagingException {
+    void sendVerificationCode_should_send_email_successfully() throws MessagingException, IOException {
         // given
         MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()));
-
         when(templateEngine.process(eq("verificationCode"), any(Context.class))).thenReturn(MOCK_HTML_CONTENT);
         when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
 
@@ -66,14 +73,14 @@ class EmailServiceTest {
 
         assertThat(capturedMessage.getSubject()).isEqualTo(VERIFICATION_EMAIL_SUBJECT);
         assertThat(capturedMessage.getRecipients(MimeMessage.RecipientType.TO)[0].toString()).isEqualTo(TO_EMAIL);
+        assertThat(capturedMessage.getFrom()[0].toString()).isEqualTo(FROM_EMAIL);
     }
 
     @Test
     @DisplayName("확정 이메일을 성공적으로 발송해야 한다.")
-    void sendConfirmationEmail_should_send_email_successfully() throws MessagingException {
+    void sendConfirmationEmail_should_send_email_successfully() throws MessagingException, IOException {
         // given
         MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()));
-
         when(templateEngine.process(eq("confirmationEmail"), any(Context.class))).thenReturn(MOCK_HTML_CONTENT);
         when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
 
@@ -86,13 +93,13 @@ class EmailServiceTest {
 
         assertThat(capturedMessage.getSubject()).isEqualTo(CONFIRMATION_EMAIL_SUBJECT);
         assertThat(capturedMessage.getRecipients(MimeMessage.RecipientType.TO)[0].toString()).isEqualTo(TO_EMAIL);
+        assertThat(capturedMessage.getFrom()[0].toString()).isEqualTo(FROM_EMAIL);
     }
 
     @Test
     @DisplayName("이메일 발송 실패 시 MailException을 던져야 한다.")
     void sendEmail_should_throw_MailException_on_failure() {
         // given
-        when(templateEngine.process(anyString(), any(Context.class))).thenReturn(MOCK_HTML_CONTENT);
         when(javaMailSender.createMimeMessage()).thenThrow(new MailException(MailErrorCode.EMAIL_SEND_FAILURE));
 
         // when & then


### PR DESCRIPTION
# 🚀 작업 내용

- `EmailService`에서 `@Value`를 통해 발신자(From) 주소를 명시적으로 설정하도록 수정
- `dev`, `test` 프로필에 `spring.mail.from` 속성을 추가하여 로컬 환경 실행 오류 해결
- `EmailServiceTest`에서 `ReflectionTestUtils`를 사용하여 `fromEmail` 필드를 초기화하고, 발신자 주소 검증 로직 추가

# 💬 리뷰 중점 사항

- 프로덕션, 개발, 테스트 환경 모두에서 이메일 발송 관련 로직이 일관되게 동작하는지 확인 부탁드립니다.
- `@Value` 어노테이션이 있는 컴포넌트의 단위 테스트를 `ReflectionTestUtils`로 처리한 방식이 적절한지 검토 부탁드립니다.

## 📸 Test Screenshot
<img width="354" height="317" alt="스크린샷 2025-09-06 오후 11 41 56" src="https://github.com/user-attachments/assets/7497968e-9224-4821-b150-927240125204" />


# 📋 연관 이슈

- close #98 
