### PR TITLE
[FEAT] AWS SES 발송 개선 및 Kafka Consumer APM 추적 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 	// Database
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	// Datadog APM Trace
+	implementation 'com.datadoghq:dd-trace-api:1.39.0'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/performance/event-test.js
+++ b/performance/event-test.js
@@ -2,7 +2,9 @@ import http from 'k6/http';
 import { check } from 'k6';
 import { SharedArray } from 'k6/data';
 
-const BASE_URL = 'http://localhost:8080';
+// const BASE_URL = 'http://localhost:8080';
+const BASE_URL = 'https://www.terning-farewell.p-e.kr';
+
 
 export const options = {
     scenarios: {

--- a/src/main/java/com/terning/farewell_server/event/application/EventConsumer.java
+++ b/src/main/java/com/terning/farewell_server/event/application/EventConsumer.java
@@ -3,6 +3,7 @@ package com.terning.farewell_server.event.application;
 import com.terning.farewell_server.application.application.ApplicationService;
 import com.terning.farewell_server.application.domain.ApplicationStatus;
 import com.terning.farewell_server.mail.application.EmailService;
+import datadog.trace.api.Trace;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.DltHandler;
@@ -22,6 +23,7 @@ public class EventConsumer {
     private final ApplicationService applicationService;
     private final EmailService emailService;
 
+    @Trace(operationName = "kafka.consume", resourceName = "EventConsumer.handleApplication")
     @RetryableTopic(
             attempts = "3",
             backoff = @Backoff(delay = 1000, multiplier = 2),

--- a/src/main/java/com/terning/farewell_server/mail/application/EmailService.java
+++ b/src/main/java/com/terning/farewell_server/mail/application/EmailService.java
@@ -26,6 +26,7 @@ public class EmailService {
 
     private static final String VERIFICATION_EMAIL_SUBJECT = "[터닝] 마지막 선물 신청을 위한 인증 코드입니다.";
     private static final String CONFIRMATION_EMAIL_SUBJECT = "[터닝] 선물 신청이 확정되었습니다.";
+    private static final String TEST_EMAIL_DOMAIN = "@example.com";
 
     public void sendVerificationCode(String toEmail, String code) {
         Context context = new Context();
@@ -37,7 +38,7 @@ public class EmailService {
     public void sendConfirmationEmail(String toEmail) {
         String targetEmail = toEmail;
 
-        if (toEmail.endsWith("@example.com")) {
+        if (toEmail.contains("@") && toEmail.endsWith(TEST_EMAIL_DOMAIN)) {
             String localPart = toEmail.substring(0, toEmail.indexOf('@'));
             targetEmail = localPart + "+success@simulator.amazonses.com";
             log.info("테스트용 이메일 감지. SES 시뮬레이터 주소로 변경: {} -> {}", toEmail, targetEmail);
@@ -60,7 +61,7 @@ public class EmailService {
 
             javaMailSender.send(mimeMessage);
             log.info("이메일 발송 성공! 수신자: {}, 제목: {}", toEmail, subject);
-        } catch (MessagingException e) {
+        } catch (MessagingException | org.springframework.mail.MailException e) {
             log.error("이메일 발송 실패. 수신자: {}", toEmail, e);
             throw new MailException(MailErrorCode.EMAIL_SEND_FAILURE);
         }

--- a/src/main/java/com/terning/farewell_server/mail/application/EmailService.java
+++ b/src/main/java/com/terning/farewell_server/mail/application/EmailService.java
@@ -35,9 +35,17 @@ public class EmailService {
     }
 
     public void sendConfirmationEmail(String toEmail) {
+        String targetEmail = toEmail;
+
+        if (toEmail.endsWith("@example.com")) {
+            String localPart = toEmail.substring(0, toEmail.indexOf('@'));
+            targetEmail = localPart + "+success@simulator.amazonses.com";
+            log.info("테스트용 이메일 감지. SES 시뮬레이터 주소로 변경: {} -> {}", toEmail, targetEmail);
+        }
+
         Context context = new Context();
         String htmlContent = templateEngine.process("confirmationEmail", context);
-        sendEmail(toEmail, CONFIRMATION_EMAIL_SUBJECT, htmlContent);
+        sendEmail(targetEmail, CONFIRMATION_EMAIL_SUBJECT, htmlContent);
     }
 
     private void sendEmail(String toEmail, String subject, String htmlBody) {

--- a/src/test/java/com/terning/farewell_server/mail/application/EmailServiceTest.java
+++ b/src/test/java/com/terning/farewell_server/mail/application/EmailServiceTest.java
@@ -2,6 +2,8 @@ package com.terning.farewell_server.mail.application;
 
 import com.terning.farewell_server.mail.exception.MailErrorCode;
 import com.terning.farewell_server.mail.exception.MailException;
+import jakarta.mail.Address;
+import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
@@ -19,13 +21,14 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
-import java.io.IOException;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -44,9 +47,7 @@ class EmailServiceTest {
     @Captor
     private ArgumentCaptor<MimeMessage> mimeMessageCaptor;
 
-    private static final String TO_EMAIL = "test@example.com";
     private static final String FROM_EMAIL = "noreply@example.com";
-    private static final String CODE = "123456";
     private static final String MOCK_HTML_CONTENT = "<html>...</html>";
     private static final String VERIFICATION_EMAIL_SUBJECT = "[터닝] 마지막 선물 신청을 위한 인증 코드입니다.";
     private static final String CONFIRMATION_EMAIL_SUBJECT = "[터닝] 선물 신청이 확정되었습니다.";
@@ -54,56 +55,82 @@ class EmailServiceTest {
     @BeforeEach
     void setUp() {
         ReflectionTestUtils.setField(emailService, "fromEmail", FROM_EMAIL);
+        when(templateEngine.process(anyString(), any(Context.class))).thenReturn(MOCK_HTML_CONTENT);
     }
 
     @Test
     @DisplayName("인증 코드 이메일을 성공적으로 발송해야 한다.")
-    void sendVerificationCode_should_send_email_successfully() throws MessagingException, IOException {
+    void sendVerificationCode_should_send_email_successfully() throws MessagingException {
         // given
-        MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()));
-        when(templateEngine.process(eq("verificationCode"), any(Context.class))).thenReturn(MOCK_HTML_CONTENT);
-        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+        String toEmail = "test@example.com";
+        String code = "123456";
+        when(javaMailSender.createMimeMessage()).thenReturn(new MimeMessage(Session.getInstance(new Properties())));
 
         // when
-        emailService.sendVerificationCode(TO_EMAIL, CODE);
+        emailService.sendVerificationCode(toEmail, code);
 
         // then
         verify(javaMailSender).send(mimeMessageCaptor.capture());
         MimeMessage capturedMessage = mimeMessageCaptor.getValue();
 
         assertThat(capturedMessage.getSubject()).isEqualTo(VERIFICATION_EMAIL_SUBJECT);
-        assertThat(capturedMessage.getRecipients(MimeMessage.RecipientType.TO)[0].toString()).isEqualTo(TO_EMAIL);
+        assertThat(capturedMessage.getRecipients(Message.RecipientType.TO)[0].toString()).isEqualTo(toEmail);
         assertThat(capturedMessage.getFrom()[0].toString()).isEqualTo(FROM_EMAIL);
     }
 
     @Test
-    @DisplayName("확정 이메일을 성공적으로 발송해야 한다.")
-    void sendConfirmationEmail_should_send_email_successfully() throws MessagingException, IOException {
+    @DisplayName("확정 이메일 발송 시 @example.com 이메일은 SES 시뮬레이터 주소로 변경되어야 한다.")
+    void sendConfirmationEmail_withTestEmail_shouldChangeToSimulatorAddress() throws MessagingException {
         // given
-        MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()));
-        when(templateEngine.process(eq("confirmationEmail"), any(Context.class))).thenReturn(MOCK_HTML_CONTENT);
-        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+        String testEmail = "test@example.com";
+        String expectedTargetEmail = "test+success@simulator.amazonses.com";
+        when(javaMailSender.createMimeMessage()).thenReturn(new MimeMessage(Session.getInstance(new Properties())));
 
         // when
-        emailService.sendConfirmationEmail(TO_EMAIL);
+        emailService.sendConfirmationEmail(testEmail);
 
         // then
         verify(javaMailSender).send(mimeMessageCaptor.capture());
         MimeMessage capturedMessage = mimeMessageCaptor.getValue();
 
         assertThat(capturedMessage.getSubject()).isEqualTo(CONFIRMATION_EMAIL_SUBJECT);
-        assertThat(capturedMessage.getRecipients(MimeMessage.RecipientType.TO)[0].toString()).isEqualTo(TO_EMAIL);
+        assertThat(capturedMessage.getRecipients(Message.RecipientType.TO)[0].toString()).isEqualTo(expectedTargetEmail);
         assertThat(capturedMessage.getFrom()[0].toString()).isEqualTo(FROM_EMAIL);
     }
 
     @Test
-    @DisplayName("이메일 발송 실패 시 MailException을 던져야 한다.")
-    void sendEmail_should_throw_MailException_on_failure() {
+    @DisplayName("확정 이메일 발송 시 일반 이메일은 원래 주소 그대로 발송되어야 한다.")
+    void sendConfirmationEmail_withRealEmail_shouldKeepOriginalAddress() throws MessagingException {
         // given
-        when(javaMailSender.createMimeMessage()).thenThrow(new MailException(MailErrorCode.EMAIL_SEND_FAILURE));
+        String realEmail = "user@realdomain.com";
+        when(javaMailSender.createMimeMessage()).thenReturn(new MimeMessage(Session.getInstance(new Properties())));
+
+        // when
+        emailService.sendConfirmationEmail(realEmail);
+
+        // then
+        verify(javaMailSender).send(mimeMessageCaptor.capture());
+        MimeMessage capturedMessage = mimeMessageCaptor.getValue();
+
+        assertThat(capturedMessage.getSubject()).isEqualTo(CONFIRMATION_EMAIL_SUBJECT);
+        assertThat(capturedMessage.getRecipients(Message.RecipientType.TO)[0].toString()).isEqualTo(realEmail);
+        assertThat(capturedMessage.getFrom()[0].toString()).isEqualTo(FROM_EMAIL);
+    }
+
+    @Test
+    @DisplayName("MimeMessageHelper 작업 실패 시 커스텀 MailException을 던져야 한다.")
+    void sendEmail_should_throw_CustomMailException_when_MimeHelperFails() throws MessagingException {
+        // given
+        MimeMessage mockMimeMessage = mock(MimeMessage.class);
+
+        when(javaMailSender.createMimeMessage()).thenReturn(mockMimeMessage);
+
+        doThrow(new MessagingException("Simulated MimeMessage failure"))
+                .when(mockMimeMessage).setFrom(any(Address.class));
 
         // when & then
-        assertThatThrownBy(() -> emailService.sendVerificationCode(TO_EMAIL, CODE))
-                .isInstanceOf(MailException.class);
+        assertThatThrownBy(() -> emailService.sendVerificationCode("fail@example.com", "123"))
+                .isInstanceOf(MailException.class)
+                .hasFieldOrPropertyWithValue("errorCode", MailErrorCode.EMAIL_SEND_FAILURE);
     }
 }


### PR DESCRIPTION
# 📄 작업 내용
* **Datadog APM 트레이싱 적용**
    * `build.gradle`에 Datadog 의존성을 추가했습니다.
    * 비동기적으로 처리되는 **Kafka Consumer**(`EventConsumer`)의 메시지 처리 과정을 추적하기 위해 `@Trace` 어노테이션을 추가하여 APM 모니터링을 적용했습니다.

* **EmailService 로직 수정 및 테스트 코드 개선**
    * **버그 수정**: 확정 이메일 발송 시, 테스트용 이메일 주소(`@example.com`)를 변환하는 로직이 있었음에도 불구하고 실제로는 변환 전 주소로 메일이 발송되던 버그를 수정했습니다.
    * **단위 테스트 리팩토링**: `EmailService`의 단위 테스트 코드 품질을 높이기 위해 전반적으로 리팩토링했습니다.
        * 테스트 의도를 명확하게 드러내도록 메서드명을 수정하고, 각 테스트의 독립성을 확보했습니다.
        * 이메일 주소 변환 로직의 모든 경우의 수(일반 이메일, 테스트 이메일)를 검증하도록 테스트 케이스를 추가했습니다.
        * 예외 발생 시나리오를 더 명확하게 테스트하도록 개선했습니다.

# 🔍 리뷰 중점사항 

코드를 작성하면서 특히 다음과 같은 부분들을 고민했습니다. 리뷰 시 이 부분들을 중점적으로 확인해주시면 감사하겠습니다!

* **1. `EmailService`의 단위 테스트 전략**
    * 기존에는 `EmailService`의 예외 처리(`try-catch`) 구문을 테스트하기가 까다로웠습니다. 프로덕션 코드를 수정하지 않으면서 `MimeMessageHelper`가 실패하는 상황을 어떻게 시뮬레이션할지 고민했습니다.
    * `MimeMessage` 자체를 모킹(Mocking)하여 `MimeMessageHelper`가 내부적으로 `setFrom`을 호출할 때 `MessagingException`을 발생시키는 방식으로 해결했습니다. 이 테스트 전략이 적절한지, 더 나은 방법은 없을지 의견 부탁드립니다.

* **2. `EmailService`의 미묘한 버그**
    * `sendConfirmationEmail` 메서드에서 이메일 주소를 변환하는 로직(`targetEmail`)은 있었지만, 정작 `sendEmail`을 호출할 때는 변환 전 주소(`toEmail`)를 사용하고 있었습니다. 이처럼 **의도와 다르게 동작하는 코드**를 발견하고 수정했는데, 혹시 다른 부분에도 비슷한 논리적 오류가 있을지 함께 봐주시면 좋을 것 같습니다.

* **3. Datadog 트레이스 네이밍 컨벤션**
    * Kafka Consumer 메서드에 `@Trace`를 적용하면서 `operationName`과 `resourceName`을 각각 `"kafka.consume"`과 `"EventConsumer.handleApplication"`으로 지정했습니다.
    * 다른 트레이스들과 일관성을 유지하고, 나중에 대시보드에서 필터링하기에 적합한 이름인지 검토 부탁드립니다.

# 📸 Test Screenshot

<img width="365" height="343" alt="스크린샷 2025-09-07 오후 3 26 19" src="https://github.com/user-attachments/assets/8690c146-9e83-4eea-b478-0af95ffc4aa3" />


# 📋 연관 이슈

- close #101 