### PR TITLE
[FEAT] Kafka를 이용한 이벤트 신청 비동기 처리 전환

### DIFF
--- a/src/main/java/com/terning/farewell_server/event/application/EventConsumer.java
+++ b/src/main/java/com/terning/farewell_server/event/application/EventConsumer.java
@@ -6,6 +6,10 @@ import com.terning.farewell_server.mail.application.EmailService;
 import datadog.trace.api.Trace;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.annotation.RetryableTopic;
@@ -15,6 +19,8 @@ import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -22,6 +28,22 @@ public class EventConsumer {
 
     private final ApplicationService applicationService;
     private final EmailService emailService;
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${event.gift-stock-key}")
+    private String giftStockKey;
+
+    private static final String DECREMENT_STOCK_LUA_SCRIPT =
+            "local stock = redis.call('decr', KEYS[1]) " +
+                    "if tonumber(stock) < 0 then " +
+                    "  redis.call('incr', KEYS[1]) " +
+                    "  return -1 " +
+                    "end " +
+                    "return stock";
+
+    private static final RedisScript<Long> DECREMENT_STOCK_SCRIPT =
+            new DefaultRedisScript<>(DECREMENT_STOCK_LUA_SCRIPT, Long.class);
+
 
     @Trace(operationName = "kafka.consume", resourceName = "EventConsumer.handleApplication")
     @RetryableTopic(
@@ -30,36 +52,25 @@ public class EventConsumer {
             dltStrategy = DltStrategy.FAIL_ON_ERROR
     )
     @KafkaListener(topics = "${event.kafka-topic}")
-    public void handleApplication(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
-        String[] parts = message.split(":");
-
-        if (parts.length != 2) {
-            log.error("잘못된 형식의 Kafka 메시지 수신 [Topic: {}]: '{}'. 'email:STATUS' 형식을 따라야 합니다.", topic, message);
-            return;
-        }
-
-        String email = parts[0];
-        ApplicationStatus status;
+    public void handleApplication(String email, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
+        log.info("Kafka 메시지 수신 [Topic: {}]: Email={}", topic, email);
 
         try {
-            status = ApplicationStatus.valueOf(parts[1]);
-        } catch (IllegalArgumentException e) {
-            log.error("유효하지 않은 ApplicationStatus 값 수신 [Topic: {}]: '{}' in message '{}'", topic, parts[1], message);
-            return;
-        }
+            Long remainingStock = redisTemplate.execute(DECREMENT_STOCK_SCRIPT, Collections.singletonList(giftStockKey));
 
-        try {
-            log.info("Kafka 메시지 수신 [Topic: {}]: Email={}, Status={}", topic, email, status);
-
-            applicationService.saveApplication(email, status);
-
-            if (status == ApplicationStatus.SUCCESS) {
-                emailService.sendConfirmationEmail(email);
+            if (remainingStock == null || remainingStock < 0) {
+                log.info("선착순 마감. [사용자: {}]", email);
+                applicationService.saveApplication(email, ApplicationStatus.FAILURE);
+                return;
             }
 
+            log.info("선착순 통과! [사용자: {}, 남은 재고: {}]", email, remainingStock);
+            applicationService.saveApplication(email, ApplicationStatus.SUCCESS);
+            emailService.sendConfirmationEmail(email);
+
         } catch (Exception e) {
-            log.error("Kafka 메시지 처리 중 비즈니스 로직 오류 발생: {}", message, e);
-            throw new RuntimeException("Kafka message processing failed for message: " + message, e);
+            log.error("Kafka 메시지 처리 중 비즈니스 로직 오류 발생: {}", email, e);
+            throw new RuntimeException("Kafka message processing failed for message: " + email, e);
         }
     }
 
@@ -68,3 +79,4 @@ public class EventConsumer {
         log.error("[DLT] 최종 처리 실패 [Topic: {}]: {}", topic, message);
     }
 }
+

--- a/src/main/java/com/terning/farewell_server/event/application/EventService.java
+++ b/src/main/java/com/terning/farewell_server/event/application/EventService.java
@@ -2,103 +2,36 @@ package com.terning.farewell_server.event.application;
 
 import com.terning.farewell_server.application.domain.Application;
 import com.terning.farewell_server.application.domain.ApplicationRepository;
-import com.terning.farewell_server.application.domain.ApplicationStatus;
 import com.terning.farewell_server.event.dto.response.StatusResponse;
 import com.terning.farewell_server.event.exception.EventErrorCode;
 import com.terning.farewell_server.event.exception.EventException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
-import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collections;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class EventService {
 
-    private static final String LOCK_KEY_PREFIX = "lock:event:apply:";
-    private static final long LOCK_WAIT_TIME_SECONDS = 10L;
-    private static final long LOCK_LEASE_TIME_SECONDS = 1L;
-
-    private static final String LOG_LOCK_ACQUISITION_FAILED = "락 획득 실패: {}";
-    private static final String LOG_EVENT_CLOSED = "선착순 마감되었습니다. [사용자: {}]";
-    private static final String LOG_EVENT_PASSED = "선착순 통과! [사용자: {}, 남은 재고: {}]";
-
-    private static final String DECREMENT_STOCK_LUA_SCRIPT =
-            "local stock = redis.call('decr', KEYS[1]) " +
-                    "if tonumber(stock) < 0 then " +
-                    "  redis.call('incr', KEYS[1]) " +
-                    "  return -1 " +
-                    "end " +
-                    "return stock";
-
-    private static final RedisScript<Long> DECREMENT_STOCK_SCRIPT =
-            new DefaultRedisScript<>(DECREMENT_STOCK_LUA_SCRIPT, Long.class);
-
-
-    private final RedissonClient redissonClient;
-    private final StringRedisTemplate redisTemplate;
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final ApplicationRepository applicationRepository;
-
-    @Value("${event.gift-stock-key}")
-    private String giftStockKey;
 
     @Value("${event.kafka-topic}")
     private String kafkaTopic;
 
-
     public void applyForGift(String email) {
-        final String lockKey = LOCK_KEY_PREFIX + email;
-        final RLock lock = redissonClient.getLock(lockKey);
-
-        try {
-            boolean isLocked = lock.tryLock(LOCK_WAIT_TIME_SECONDS, LOCK_LEASE_TIME_SECONDS, TimeUnit.SECONDS);
-            if (!isLocked) {
-                log.warn(LOG_LOCK_ACQUISITION_FAILED, email);
-                throw new EventException(EventErrorCode.ALREADY_PROCESSING_REQUEST);
-            }
-
-            Long remainingStock = redisTemplate.execute(DECREMENT_STOCK_SCRIPT, Collections.singletonList(giftStockKey));
-
-            if (remainingStock == null) {
-                throw new EventException(EventErrorCode.GIFT_STOCK_INFO_NOT_FOUND);
-            }
-
-            if (remainingStock < 0) {
-                log.info(LOG_EVENT_CLOSED, email);
-                kafkaTemplate.send(kafkaTopic, email + ":" + ApplicationStatus.FAILURE.name());
-                throw new EventException(EventErrorCode.EVENT_CLOSED);
-            }
-
-            log.info(LOG_EVENT_PASSED, email, remainingStock);
-            kafkaTemplate.send(kafkaTopic, email + ":" + ApplicationStatus.SUCCESS.name());
-
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new EventException(EventErrorCode.LOCK_ACQUISITION_FAILED);
-        } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
+        log.info("이벤트 신청 접수. Kafka 토픽으로 메시지 발행: {}", email);
+        kafkaTemplate.send(kafkaTopic, email);
     }
 
     @Transactional(readOnly = true)
     public StatusResponse getApplicationStatus(String email) {
         Application application = applicationRepository.findByEmail(email)
                 .orElseThrow(() -> new EventException(EventErrorCode.APPLICATION_NOT_FOUND));
-
         return StatusResponse.from(application);
     }
 }

--- a/src/test/java/com/terning/farewell_server/event/application/EventConsumerTest.java
+++ b/src/test/java/com/terning/farewell_server/event/application/EventConsumerTest.java
@@ -3,6 +3,7 @@ package com.terning.farewell_server.event.application;
 import com.terning.farewell_server.application.application.ApplicationService;
 import com.terning.farewell_server.application.domain.ApplicationStatus;
 import com.terning.farewell_server.mail.application.EmailService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,19 +11,27 @@ import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 @ExtendWith(MockitoExtension.class)
 class EventConsumerTest {
+
+    @InjectMocks
+    private EventConsumer eventConsumer;
 
     @Mock
     private ApplicationService applicationService;
@@ -30,22 +39,27 @@ class EventConsumerTest {
     @Mock
     private EmailService emailService;
 
-    @InjectMocks
-    private EventConsumer eventConsumer;
+    @Mock
+    private StringRedisTemplate redisTemplate;
 
     private static final String EMAIL = "test@example.com";
     private static final String TOPIC = "event-application";
+    private static final String GIFT_STOCK_KEY = "event:gift:stock";
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(eventConsumer, "giftStockKey", GIFT_STOCK_KEY);
+    }
 
     @Test
-    @DisplayName("SUCCESS 상태의 Kafka 메시지 수신 시, 신청 내역 저장과 이메일 발송이 순서대로 호출된다.")
-    void handleApplication_Success() {
+    @DisplayName("재고가 남아있을 때(Redis decr >= 0), SUCCESS 상태로 저장하고 확인 이메일을 발송한다.")
+    void handleApplication_whenStockAvailable_thenProcessSuccess() {
         // given
-        String successMessage = EMAIL + ":" + ApplicationStatus.SUCCESS.name();
-        doNothing().when(applicationService).saveApplication(EMAIL, ApplicationStatus.SUCCESS);
-        doNothing().when(emailService).sendConfirmationEmail(EMAIL);
+        when(redisTemplate.execute(any(RedisScript.class), any(List.class)))
+                .thenReturn(99L);
 
         // when
-        eventConsumer.handleApplication(successMessage, TOPIC);
+        eventConsumer.handleApplication(EMAIL, TOPIC);
 
         // then
         InOrder inOrder = inOrder(applicationService, emailService);
@@ -54,35 +68,50 @@ class EventConsumerTest {
     }
 
     @Test
-    @DisplayName("FAILURE 상태의 Kafka 메시지 수신 시, 신청 내역만 저장되고 이메일 발송은 호출되지 않는다.")
-    void handleApplication_Failure_Status() {
+    @DisplayName("재고가 소진되었을 때(Redis decr < 0), FAILURE 상태로 저장하고 이메일은 발송하지 않는다.")
+    void handleApplication_whenStockExhausted_thenProcessFailure() {
         // given
-        String failureMessage = EMAIL + ":" + ApplicationStatus.FAILURE.name();
-        doNothing().when(applicationService).saveApplication(EMAIL, ApplicationStatus.FAILURE);
+        when(redisTemplate.execute(any(RedisScript.class), any(List.class)))
+                .thenReturn(-1L);
 
         // when
-        eventConsumer.handleApplication(failureMessage, TOPIC);
+        eventConsumer.handleApplication(EMAIL, TOPIC);
 
         // then
         verify(applicationService, times(1)).saveApplication(EMAIL, ApplicationStatus.FAILURE);
-        verify(emailService, never()).sendConfirmationEmail(anyString());
+        verify(emailService, never()).sendConfirmationEmail(EMAIL);
     }
 
     @Test
-    @DisplayName("신청 내역 저장 중 예외 발생 시, 런타임 예외를 다시 던져야 한다.")
-    void handleApplication_Fail_On_Save() {
+    @DisplayName("Redis 스크립트 실행 결과가 null일 때, FAILURE 상태로 저장하고 이메일은 발송하지 않는다.")
+    void handleApplication_whenRedisReturnsNull_thenProcessFailure() {
         // given
-        String successMessage = EMAIL + ":" + ApplicationStatus.SUCCESS.name();
+        when(redisTemplate.execute(any(RedisScript.class), any(List.class)))
+                .thenReturn(null);
+
+        // when
+        eventConsumer.handleApplication(EMAIL, TOPIC);
+
+        // then
+        verify(applicationService, times(1)).saveApplication(EMAIL, ApplicationStatus.FAILURE);
+        verify(emailService, never()).sendConfirmationEmail(EMAIL);
+    }
+
+    @Test
+    @DisplayName("DB 저장 중 예외가 발생하면, 이메일 발송은 시도되지 않고 런타임 예외를 다시 던져야 한다.")
+    void handleApplication_whenDbFails_thenThrowRuntimeException() {
+        // given
+        when(redisTemplate.execute(any(RedisScript.class), any(List.class)))
+                .thenReturn(99L);
         doThrow(new RuntimeException("DB 저장 실패"))
                 .when(applicationService).saveApplication(EMAIL, ApplicationStatus.SUCCESS);
 
         // when & then
         assertThrows(RuntimeException.class, () -> {
-            eventConsumer.handleApplication(successMessage, TOPIC);
+            eventConsumer.handleApplication(EMAIL, TOPIC);
         });
 
         // then
-        verify(applicationService, times(1)).saveApplication(EMAIL, ApplicationStatus.SUCCESS);
-        verify(emailService, never()).sendConfirmationEmail(anyString());
+        verify(emailService, never()).sendConfirmationEmail(EMAIL);
     }
 }

--- a/src/test/java/com/terning/farewell_server/event/application/EventServiceTest.java
+++ b/src/test/java/com/terning/farewell_server/event/application/EventServiceTest.java
@@ -5,150 +5,50 @@ import com.terning.farewell_server.application.domain.ApplicationRepository;
 import com.terning.farewell_server.application.domain.ApplicationStatus;
 import com.terning.farewell_server.event.dto.response.StatusResponse;
 import com.terning.farewell_server.event.exception.EventException;
-import com.terning.farewell_server.util.IntegrationTestSupport;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
+class EventServiceTest {
 
-@SpringBootTest
-class EventServiceTest extends IntegrationTestSupport {
-
-    @Autowired
+    @InjectMocks
     private EventService eventService;
 
-    @Autowired
-    private StringRedisTemplate redisTemplate;
-
-    @MockBean
-    private ApplicationRepository applicationRepository;
-
-    @MockBean
+    @Mock
     private KafkaTemplate<String, String> kafkaTemplate;
 
-    @MockBean
-    private EventConsumer eventConsumer;
+    @Mock
+    private ApplicationRepository applicationRepository;
 
-    @Value("${event.gift-stock-key}")
-    private String giftStockKey;
-
-    @Captor
-    private ArgumentCaptor<String> kafkaMessageCaptor;
-
-    private static final int INITIAL_STOCK = 100;
+    private static final String KAFKA_TOPIC = "event-application";
     private static final String EMAIL = "user@example.com";
 
-    @BeforeEach
-    void setUp() {
-        redisTemplate.opsForValue().set(giftStockKey, String.valueOf(INITIAL_STOCK));
-        reset(kafkaTemplate, applicationRepository);
-    }
-
     @Test
-    @DisplayName("한 명의 사용자가 성공적으로 선물을 신청하면 SUCCESS 메시지를 Kafka로 보낸다.")
-    void applyForGift_Success() {
+    @DisplayName("이벤트 신청 시, Kafka로 사용자 이메일 메시지를 정확히 한 번 발행해야 한다.")
+    void applyForGift_shouldSendEmailToKafka() {
         // given
-        String successUserEmail = "user1@example.com";
+        ReflectionTestUtils.setField(eventService, "kafkaTopic", KAFKA_TOPIC);
 
         // when
-        eventService.applyForGift(successUserEmail);
+        eventService.applyForGift(EMAIL);
 
         // then
-        String stock = redisTemplate.opsForValue().get(giftStockKey);
-        assertThat(stock).isEqualTo(String.valueOf(INITIAL_STOCK - 1));
-
-        String expectedMessage = successUserEmail + ":" + ApplicationStatus.SUCCESS.name();
-        verify(kafkaTemplate, times(1)).send(anyString(), eq(expectedMessage));
-    }
-
-    @Test
-    @DisplayName("재고 소진 후 신청하면 예외가 발생하고 FAILURE 메시지를 Kafka로 보낸다.")
-    void applyForGift_Fail_When_Stock_Is_Exhausted() {
-        // given
-        redisTemplate.opsForValue().set(giftStockKey, "0");
-        String lateUserEmail = "late_user@example.com";
-
-        // when & then
-        assertThrows(EventException.class, () -> {
-            eventService.applyForGift(lateUserEmail);
-        });
-
-        String stock = redisTemplate.opsForValue().get(giftStockKey);
-        assertThat(stock).isEqualTo("0");
-
-        String expectedMessage = lateUserEmail + ":" + ApplicationStatus.FAILURE.name();
-        verify(kafkaTemplate, times(1)).send(anyString(), eq(expectedMessage));
-    }
-
-    @Test
-    @DisplayName("10,000명이 동시 신청하면, SUCCESS 100건과 FAILURE 9,900건의 메시지가 Kafka로 전송된다.")
-    void applyForGift_Concurrency_Test() throws InterruptedException {
-        // given
-        int numberOfThreads = 100;
-        int totalRequests = 10000;
-
-        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
-        CountDownLatch latch = new CountDownLatch(totalRequests);
-
-        // when
-        IntStream.range(0, totalRequests).forEach(i ->
-                executorService.submit(() -> {
-                    try {
-                        eventService.applyForGift("user" + i + "@example.com");
-                    } catch (EventException e) {
-                        // EventException은 정상적인 실패이므로 무시
-                    } finally {
-                        latch.countDown();
-                    }
-                })
-        );
-
-        latch.await();
-        executorService.shutdown();
-
-        // then
-        String stock = redisTemplate.opsForValue().get(giftStockKey);
-        assertThat(stock).isEqualTo("0");
-
-        verify(kafkaTemplate, times(totalRequests)).send(anyString(), kafkaMessageCaptor.capture());
-
-        List<String> capturedMessages = kafkaMessageCaptor.getAllValues();
-
-        long successCount = capturedMessages.stream()
-                .filter(message -> message.endsWith(":" + ApplicationStatus.SUCCESS.name()))
-                .count();
-
-        long failureCount = capturedMessages.stream()
-                .filter(message -> message.endsWith(":" + ApplicationStatus.FAILURE.name()))
-                .count();
-
-        assertThat(successCount).isEqualTo(INITIAL_STOCK);
-        assertThat(failureCount).isEqualTo(totalRequests - INITIAL_STOCK);
+        verify(kafkaTemplate, times(1)).send(KAFKA_TOPIC, EMAIL);
     }
 
     @Test
@@ -156,9 +56,8 @@ class EventServiceTest extends IntegrationTestSupport {
     void getApplicationStatus_Success() {
         // given
         Application mockApplication = mock(Application.class);
-        when(mockApplication.getEmail()).thenReturn(EMAIL);
         when(mockApplication.getStatus()).thenReturn(ApplicationStatus.SUCCESS);
-        when(applicationRepository.findByEmail(anyString()))
+        when(applicationRepository.findByEmail(EMAIL))
                 .thenReturn(Optional.of(mockApplication));
 
         // when
@@ -166,17 +65,17 @@ class EventServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(response.status()).isEqualTo(ApplicationStatus.SUCCESS.name());
-        assertThat(response.message()).isEqualTo("신청 결과: " + ApplicationStatus.SUCCESS.name());
     }
 
     @Test
     @DisplayName("신청 내역이 없는 사용자의 상태 조회 시 예외가 발생한다.")
     void getApplicationStatus_Fail_WhenNotFound() {
         // given
-        when(applicationRepository.findByEmail(anyString()))
+        when(applicationRepository.findByEmail(EMAIL))
                 .thenReturn(Optional.empty());
 
         // when & then
         assertThrows(EventException.class, () -> eventService.getApplicationStatus(EMAIL));
     }
 }
+


### PR DESCRIPTION
# 🚀 작업 내용

## **1. 이벤트 신청 로직의 완전한 비동기 아키텍처 전환**

  - 기존의 동기(Synchronous) 처리 방식에서 발생하는 극심한 성능 저하(p95 \> 30s)를 해결하기 위해, Kafka 메시지 큐를 활용한 비동기(Asynchronous) 처리 아키텍처로 전면 개편했습니다.
  - **`EventService` (API 계층):** 이제 '접수 창구' 역할만 수행합니다. 사용자 요청을 받으면 즉시 Kafka 토픽으로 메시지를 발행하고 `2022-Accepted` 응답을 반환합니다.
  - **`EventConsumer` (처리 계층):** '처리 창구' 역할을 담당합니다. Kafka로부터 메시지를 받아 실제 재고 차감, DB 저장, 이메일 발송 등 모든 비즈니스 로직을 순차적으로 처리합니다.

### **2. Redisson 분산 락(Distributed Lock) 제거 및 원자적 연산(Atomic Operation) 도입**

  - 비동기 처리로 전환함에 따라, 기존 성능 병목의 핵심 원인이었던 Redisson 분산 락 로직을 **완전히 제거**했습니다.
  - `EventConsumer`에서는 다수의 스레드가 경쟁하지 않으므로, 더 가볍고 효율적인 Redis의 원자적 연산 명령어(`DECR`)를 Lua 스크립트로 실행하여 재고를 안전하게 차감합니다.

### **3. '선착순 마감' 처리 방식 개선 (에러 -\> 정상 흐름)**

  - 선착순 마감을 시스템 예외(`Exception`)로 처리하던 기존 방식은 APM 모니터링에 불필요한 에러를 발생시키고, Kafka의 재시도 로직을 낭비하는 원인이었습니다.
  - 이를 정상적인 비즈니스 흐름으로 간주하고, **Guard Clause 패턴**을 적용하여 `if/return`으로 처리하도록 리팩토링했습니다. 
  

# 💬 리뷰 중점 사항

### **1. 왜 단순한 튜닝이 아닌, 아키텍처 변경을 선택했는가?**

최초 APM 데이터에서 발견된 p95 응답 시간 30초 이상의 원인은 단순한 코드 비효율을 넘어, **동기 처리 방식이 대규모 동시 요청(Burst Traffic)을 감당하지 못하는 구조적인 한계**에 있었습니다.  `Redisson Lock`은 데이터 정합성을 보장했지만, 수천 개의 스레드가 하나의 락을 기다리며 시스템 전체를 마비시켰습니다.
이번 비동기 전환은 이 근본적인 문제를 해결하기 위한 선택이었습니다. API 서버를 트래픽의 Buffer로 만들어 사용자에게 즉각적인 응답 경험을 제공하고, 실제 처리는 시스템이 감당할 수 있는 속도로 안정적으로 수행하도록 역할을 분리했습니다.

### **2. Redis: 병목의 원인에서, 효율적인 도구로**

이전 구조에서 Redis는 `Lock` 경합으로 인해 병목처럼 보였지만, 실제로는 제가 Redis를 사용하는 방식의 문제였습니다. Kafka를 통해 요청을 **직렬화(Serialize)** 함으로써, 우리는 더 이상 여러 스레드의 동시 접근을 걱정할 필요가 없어졌습니다.
그 결과, 무거운 분산 락 대신 Redis가 가장 잘하는 원자적 연산(`DECR`)을 활용할 수 있게 되었습니다. 이는 'Lock -\> Get -\> Set -\> Unlock'의 복잡한 과정을 단 하나의 명령으로 대체하여, 코드의 복잡성과 실행 시간을 모두 극적으로 줄여줍니다.

### **3. "선착순 마감은 에러가 아니다": 코드와 모니터링의 명확성**

개발 초기에는 선착순 마감을 비즈니스 예외(`EventException`)로 처리했습니다. 하지만 이는 두 가지 문제를 야기했습니다.

  - **모니터링 오염:** APM에서 정상적인 비즈니스 마감이 '에러'로 집계되어, 실제 시스템 장애와 구분이 어려워집니다.
  - **불필요한 리소스 낭비:** Kafka의 `@RetryableTopic`은 이 '성공할 수 없는 실패'를 계속 재시도하여 불필요한 부하를 유발합니다.
    이번 리팩토링을 통해 선착순 마감을 **정상적인 비즈니스 흐름**으로 명확히 정의함으로써, 시스템의 안정성과 Observability을 모두 높였습니다.

## 📸 Test Screenshot

<img width="362" height="325" alt="스크린샷 2025-09-07 오후 6 04 45" src="https://github.com/user-attachments/assets/2a12d3c5-5ec8-478c-b8c2-49cc6943e03a" />


# 📋 연관 이슈

- close #112 