### PR TITLE
[FEAT] 대규모 동시 요청 처리를 위한 웹 서버 스레드 풀 확장

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,5 +1,12 @@
 # src/main/resources/application-dev.yml
 
+server:
+  tomcat:
+    threads:
+      max: 1600
+      min-spare: 50
+    accept-count: 200
+
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -2,6 +2,11 @@
 
 server:
   port: ${SERVER_PORT:8080}
+  tomcat:
+    threads:
+      max: 1600
+      min-spare: 50
+    accept-count: 200
 
 spring:
   config:
@@ -33,9 +38,8 @@ spring:
       group-id: farewell-group-prod
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-serializer: org.apache.kafka.common.serialization.StringDeserializer
   mail:
-    #    host: smtp.gmail.com
     host: email-smtp.ap-northeast-2.amazonaws.com
     port: 587
     username: ${MAIL_USERNAME}


### PR DESCRIPTION
# 🚀 작업 내용
- 내장 웹 서버(Tomcat) 스레드 풀 및 연결 큐 튜닝

  - k6 부하 테스트에서 발생한 EOF (Connection Reset) 오류를 해결하기 위해 내장 웹 서버인 Tomcat의 처리 용량을 증설했습니다.
  - application-prod.yml과 application-dev.yml 파일에 아래 설정을 추가했습니다.
    - server.tomcat.threads.max: 1600 (k6 VUs 1500개 이상을 수용)
    - server.tomcat.threads.min-spare: 50
    - server.tomcat.accept-count: 200

# 💬 리뷰 중점 사항

"병목은 이동한다": 비즈니스 로직에서 인프라로

이전 PR들에서 비즈니스 로직의 병목(Redisson Lock)을 성공적으로 해결하자, 병목 지점은 다음 단계인 웹 서버의 연결 처리 용량으로 이동했습니다. 

EOF 오류는 Spring Boot 앱의 코드가 느려서가 아니라, 앱으로 들어오는 요청을 받아주는 Tomcat의 수용 인원이 부족하여 연결 자체가 끊어지는 문제였습니다. 

이번 PR은 코드 로직의 변경이 아닌, 애플리케이션이 실행되는 환경의 처리 용량을 늘리는 인프라 레벨의 튜닝입니다. Tomcat의 최대 스레드 수를 부하 테스트의 가상 유저 수(1500) 이상으로 설정함으로써, 모든 요청을 안정적으로 받아 Kafka 큐로 전달할 수 있도록 보장합니다.

API는 대부분의 무거운 작업을 Kafka에 위임하는 I/O-bound 특성을 가지므로, VUs 수에 맞게 스레드 풀을 확장하는 것이 CPU 부하 없이 시스템 처리량을 극대화하는 가장 효과적인 전략이라고 생각하였습니다.

# 📋 연관 이슈

- close #115 
