### PR TITLE
[FEAT] Kafka Consumer 동시성 설정을 통한 처리량 증대

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,9 +9,6 @@ server:
     accept-count: 200
 
 spring:
-  config:
-    activate:
-      on-profile: prod
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DATASOURCE_URL}
@@ -19,45 +16,61 @@ spring:
     password: ${DATASOURCE_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     properties:
       hibernate:
-        format_sql: false
+        format_sql: true
         default_batch_fetch_size: 100
     open-in-view: false
   data:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+
+  mail:
+    # --- [로컬 성능 테스트용: MailHog 사용 시] ---
+    host: localhost
+    port: 1025
+    from: test@example.com # [수정] from 주소 추가
+    properties:
+      mail:
+        smtp:
+          auth: false
+          starttls:
+            enable: false
+
+    # --- [개발/배포용: Gmail 등 실제 메일 서버 사용 시] ---
+    # host: smtp.gmail.com
+    # port: 587
+    # from: your-email@gmail.com
+    # username: ${MAIL_USERNAME}
+    # password: ${MAIL_PASSWORD}
+    # properties:
+    #   mail:
+    #     smtp:
+    #       auth: true
+    #       starttls:
+    #         enable: true
+
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
     consumer:
-      group-id: farewell-group-prod
+      group-id: farewell-group
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-  mail:
-    host: email-smtp.ap-northeast-2.amazonaws.com
-    port: 587
-    username: ${MAIL_USERNAME}
-    password: ${MAIL_PASSWORD}
-    from: noreply@terning-farewell.p-e.kr
-    properties:
-      mail:
-        smtp:
-          auth: true
-          starttls:
-            enable: true
+    listener:
+      concurrency: 10
 
 redisson:
-  file: classpath:redisson-config-prod.yml
+  file: classpath:redisson-config.yml
 
 event:
-  gift-stock-key: "event:gift:stock:prod"
-  kafka-topic: "event-application-prod"
+  gift-stock-key: "event:gift:stock"
+  kafka-topic: "event-application"
 
 admin:
   secret-key: ${ADMIN_SECRET_KEY}
@@ -71,7 +84,8 @@ jwt:
 
 logging:
   level:
-    org.hibernate.SQL: info
+    org.hibernate.SQL: debug
+    com.terning.farewell_server: debug
 
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -38,7 +38,9 @@ spring:
       group-id: farewell-group-prod
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-serializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    listener:
+      concurrency: 10
   mail:
     host: email-smtp.ap-northeast-2.amazonaws.com
     port: 587


### PR DESCRIPTION
# 🚀 작업 내용

1. Kafka Consumer 동시성(Concurrency) 설정을 통한 처리량 증대
  - k6 부하 테스트에서 발견된 마지막 병목 지점인 Consumer의 처리량 한계를 해결했습니다.
  - (선행 작업) Kafka 토픽(event-application-prod)의 파티션 수를 10개로 확장했습니다.
  - application-prod.yml과 application-dev.yml에 spring.kafka.listener.concurrency: 10 옵션을 추가하여, 10개의 스레드가 메시지를 병렬로 처리하도록 설정했습니다.

2. dev 환경 설정(application-dev.yml) 정상화
  - prod 설정이 잘못 복사되어 있던 application-dev.yml 파일을 정상적인 개발 환경에 맞게 수정했습니다.
  - ddl-auto: update, SQL 포매팅 활성화, MailHog 설정, dev용 Kafka 그룹 ID 및 토픽 이름 등 개발 환경에 적합한 구성으로 변경했습니다.

3. Kafka Consumer 설정 오타 수정
  - 이전 AI 코드 리뷰에서 지적된 application-prod.yml의 Kafka Consumer 설정 오타(value-serializer -> value-deserializer)를 수정했습니다.

# 💬 고민한 부분

마지막 병목 해결: 계산대 증설하기

이전 PR들을 통해 API 서버의 병목(Lock 경합, Tomcat 스레드 풀)을 모두 해결하자, 시스템의 부하는 예상대로 Kafka Consumer로 이동했습니다. 단일 스레드로 동작하는 Consumer가 1,500개의 메시지를 순차 처리하면서 Kafka 토픽에 심각한 백로그(Backlog)가 발생했고, 이는 결국 생산자(Producer)에게까지 영향을 미치는 백프레셔(Backpressure) 현상으로 이어져 API 응답 지연 및 타임아웃(504 Gateway Timeout)의 원인이 되었습니다.

이번 PR은 "파티션을 10개로 증설"하여 이 문제를 해결합니다.

1. 파티션 확장 : Kafka 토픽의 파티션을 10개로 늘려, 메시지가 10개의 큐에 분산되도록 물리적인 통로를 확장했습니다.

2. 동시성 설정 : listener.concurrency: 10 설정은 Spring Kafka에게 "10개의 스레드를 배치하여, 10개의 파티션을 각각 전담 처리하라"고 지시하는 것입니다.

이 두 가지 작업을 통해 Consumer의 전체 처리 속도를 이론적으로 10배 향상시켜, k6 부하 테스트의 성능 목표(p(95) < 1000ms)를 달성할 수 있도록 구성했습니다.

리뷰 시, dev와 prod 환경의 설정이 이제 명확히 분리되었는지, 그리고 Consumer 동시성 설정이 적절한지 함께 검토해주시면 감사하겠습니다.

# 📋 연관 이슈
- close #118 


