### PR TITLE
[FEAT] @Async를 이용한 비동기 처리로 스레드 누수 문제 해결

### DIFF
--- a/src/main/java/com/terning/farewell_server/FarewellServerApplication.java
+++ b/src/main/java/com/terning/farewell_server/FarewellServerApplication.java
@@ -2,12 +2,13 @@ package com.terning.farewell_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class FarewellServerApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(FarewellServerApplication.class, args);
 	}
-
 }

--- a/src/main/java/com/terning/farewell_server/global/config/AsyncConfig.java
+++ b/src/main/java/com/terning/farewell_server/global/config/AsyncConfig.java
@@ -1,0 +1,22 @@
+package com.terning.farewell_server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "mailExecutor")
+    public Executor mailExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("MailExecutor-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/terning/farewell_server/global/config/AsyncConfig.java
+++ b/src/main/java/com/terning/farewell_server/global/config/AsyncConfig.java
@@ -5,17 +5,25 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 
 @Configuration
 public class AsyncConfig {
 
+    private static final int CORE_POOL_SIZE = 10;
+    private static final int MAX_POOL_SIZE = 20;
+    private static final int QUEUE_CAPACITY = 500;
+
     @Bean(name = "mailExecutor")
     public Executor mailExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(10);
-        executor.setMaxPoolSize(20);
-        executor.setQueueCapacity(500);
+        executor.setCorePoolSize(CORE_POOL_SIZE);
+        executor.setMaxPoolSize(MAX_POOL_SIZE);
+        executor.setQueueCapacity(QUEUE_CAPACITY);
         executor.setThreadNamePrefix("MailExecutor-");
+
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/terning/farewell_server/mail/application/EmailService.java
+++ b/src/main/java/com/terning/farewell_server/mail/application/EmailService.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
@@ -35,6 +36,7 @@ public class EmailService {
         sendEmail(toEmail, VERIFICATION_EMAIL_SUBJECT, htmlContent);
     }
 
+    @Async("mailExecutor")
     public void sendConfirmationEmail(String toEmail) {
         String targetEmail = toEmail;
 


### PR DESCRIPTION
# 🚀 작업 내용

Datadog APM에서 발견된 심각한 스레드 누수(Thread Leak) 및 메모리 누수 문제를 해결하기 위해, 동기 방식으로 동작하던 EmailService를 비동기 방식으로 전환했습니다.

1. `@EnableAsync` 활성화:
  - 메인 애플리케이션 클래스(FarewellServerApplication)에 `@EnableAsync` 어노테이션을 추가하여 Spring의 비동기 처리 기능을 활성화했습니다.

2. 전용 스레드 풀(ThreadPoolTaskExecutor) 설정:
  - AsyncConfig 클래스를 새로 생성하여, 이메일 발송 전용 스레드 풀인 mailExecutor를 Bean으로 등록했습니다. 

3. `@Async` 적용:
  - EmailService의 sendConfirmationEmail 메소드에 `@Async`("mailExecutor") 어노테이션을 적용했습니다.
  - 이제 Kafka Consumer 스레드는 이메일 발송 작업이 끝날 때까지 기다리지 않고, mailExecutor에게 작업을 위임한 뒤 즉시 다음 메시지를 처리하러 갑니다.

# 💬 고민했던 부분

스레드 누수 해결

지금까지의 모든 튜닝에도 불구하고 성능이 개선되지 않았던 근본적인 원인은, Datadog APM이 명확히 보여준 스레드 수의 비정상적인 폭증이었습니다.

이는 javaMailSender.send()가 동기적으로 동작하여 외부 SMTP 서버의 응답을 기다리는 동안, 해당 메시지를 처리하던 Kafka Consumer 스레드를 장시간 붙잡아두기(Blocking) 때문이었습니다. 10개의 Consumer 스레드가 모두 이메일 발송 작업에 묶여버리면, Kafka 토픽에는 메시지가 계속 쌓이고 시스템 전체가 마비되는 결과를 낳았습니다.

이번 PR은 `@Async`를 통해 이메일 발송이라는 느린 I/O 작업을 별도의 스레드 풀에 위임하여, Kafka Consumer 스레드가 자신의 핵심 임무인 '메시지 소비 및 DB/Redis 작업'에만 집중할 수 있도록 만듭니다.

이를 통해 Blocked Threads 문제를 해결하고, 안정적인 스레드 수와 메모리 사용량을 유지하여 최종적으로 목표 성능(p(95) < 1000ms)을 달성하고자 합니다.

# 📋 연관 이슈

- close #124 
